### PR TITLE
[ECO-552]: Update manual test to run in separate repo. 

### DIFF
--- a/manual-test/README.md
+++ b/manual-test/README.md
@@ -1,7 +1,6 @@
 # Manual Testing
 
-This directory holds tests of the client into the network
-with `CasperLabs/hack/docker`.
+This directory holds tests of the Clarity into the network with `CasperLabs/hack/docker` and assumes that `clarity` repo is at the same directory level as the CasperLabs repo.
 
  - Run `./build_casperlabs.sh` to build docker images.
  - Run `./standup.sh` to bring up 3 node network.

--- a/manual-test/build_casperlabs.sh
+++ b/manual-test/build_casperlabs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 # build docker images to use
-cd ../.. || exit 1
-make docker-build-all
+cd ../ || exit 1
+make docker-build/clarity

--- a/manual-test/standup.sh
+++ b/manual-test/standup.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 
-export CL_VERSION=latest
+TAG=${CL_VERSION:-"latest"}
+docker pull casperlabs/execution-engine:"$TAG"
+docker pull casperlabs/node:"$TAG"
+docker pull casperlabs/key-generator:"$TAG"
+
+export CL_VERSION="$TAG"
 export AUTH_MOCK_ENABLED=true
 
 # Stand up highway network
-cd ../../hack/docker || exit 1
+cd ../../CasperLabs/hack/docker || exit
 make up-all || exit 1
 
 # Sleep until network starts.

--- a/manual-test/teardown.sh
+++ b/manual-test/teardown.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 # Shutdown highway network
-cd ../../hack/docker || exit 1
+cd ../../CasperLabs/hack/docker || exit 1
 make clean

--- a/manual-test/tests/common.py
+++ b/manual-test/tests/common.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 
 THIS_DIRECTORY = Path(os.path.dirname(os.path.realpath(__file__)))
-CASPERLABS_ROOT_DIRECTORY = THIS_DIRECTORY.parent.parent.parent
+CASPERLABS_ROOT_DIRECTORY = THIS_DIRECTORY.parent.parent.parent / "CasperLabs"
 
 HACK_DOCKER_DIRECTORY = CASPERLABS_ROOT_DIRECTORY / "hack" / "docker"
 KEYS_DIRECTORY = HACK_DOCKER_DIRECTORY / "keys"


### PR DESCRIPTION
### Overview
Update the manual test so that it could run from the repo. The manual test assume that `clarity` repo is at the same directory level as the CasperLabs repo.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-552

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [X] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
