### PR TITLE
[ECO-626]

### DIFF
--- a/packages/ui/src/components/BlockList.tsx
+++ b/packages/ui/src/components/BlockList.tsx
@@ -8,6 +8,7 @@ import {
 } from './Utils';
 import DataTable from './DataTable';
 import { BlockInfo } from 'casperlabs-grpc/io/casperlabs/casper/consensus/info_pb';
+import { Block } from 'casperlabs-grpc/io/casperlabs/casper/consensus/consensus_pb';
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import Pages from './Pages';
 import { encodeBase16 } from 'casperlabs-sdk';
@@ -56,6 +57,9 @@ class _BlockList extends React.Component<Props, {}> {
         }
         refresh={() => this.refresh()}
         subscribeToggleStore={dag.toggleableSubscriber.subscribeToggleStore}
+        filterToggleStore={dag.hideBallotsToggleStore}
+        filterTtl='Only show blocks'
+        filterLbl='Hide Ballots'
         headers={[
           'Block Hash',
           'j-Rank',
@@ -92,6 +96,10 @@ class _BlockList extends React.Component<Props, {}> {
               </td>
             </tr>
           );
+        }}
+        filterRow={(block: BlockInfo) => {
+          let msgType=block.getSummary()?.getHeader()?.getMessageType(); 
+          return msgType==Block.MessageType.BLOCK;
         }}
         footerMessage={
           <DagStepButtons

--- a/packages/ui/src/components/DataTable.tsx
+++ b/packages/ui/src/components/DataTable.tsx
@@ -8,6 +8,10 @@ export interface Props<T> {
   title: string;
   refresh?: () => void;
   subscribeToggleStore?: ToggleStore;
+  filterToggleStore?: ToggleStore;
+  filterRow?: (x: T, idx: number) => Boolean;
+  filterTtl?: string;
+  filterLbl?: string;
   headers: string[];
   rows: T[] | null;
   emptyMessage?: any;
@@ -23,18 +27,29 @@ export default class DataTable<T> extends React.Component<Props<T>,{}> {
       <div className="card mb-3">
         <div className="card-header">
           <span>{this.props.title}</span>
+          {this.props.refresh && (
+            <div className="float-right">
+              <RefreshButton refresh={() => this.props.refresh!()} />
+            </div>
+          )}
           {this.props.subscribeToggleStore && (
             <div className="float-right">
               <ToggleButton
                 title="Subscribe to latest changes"
+                label="Live Feed"
                 toggleStore={this.props.subscribeToggleStore}
                 size="sm"
               />
             </div>
           )}
-          {this.props.refresh && (
+          {this.props.filterToggleStore && (
             <div className="float-right">
-              <RefreshButton refresh={() => this.props.refresh!()} />
+              <ToggleButton
+                title={this.props.filterTtl}
+                label={this.props.filterLbl}
+                toggleStore={this.props.filterToggleStore}
+                size="sm"
+              />
             </div>
           )}
         </div>
@@ -60,7 +75,11 @@ export default class DataTable<T> extends React.Component<Props<T>,{}> {
                   </tr>
                 </thead>
               )}
-              <tbody>{this.props.rows.map(this.props.renderRow)}</tbody>
+              <tbody>{this.props.filterRow && 
+              this.props.filterToggleStore?.isPressed
+                      ? this.props.rows.filter(this.props.filterRow).map(this.props.renderRow)
+                      : this.props.rows.map(this.props.renderRow)}
+              </tbody>
             </table>
           )}
         </div>

--- a/smart-contract/Makefile
+++ b/smart-contract/Makefile
@@ -1,5 +1,8 @@
+RUST_TOOLCHAIN := $(shell cat rust-toolchain)
+
 prepare:
-	rustup target add wasm32-unknown-unknown
+	rustup toolchain install --no-self-update $(RUST_TOOLCHAIN)
+	rustup target add --toolchain $(RUST_TOOLCHAIN) wasm32-unknown-unknown
 
 build-contracts:
 	cargo build --release -p faucet-stored --target wasm32-unknown-unknown


### PR DESCRIPTION
### Overview

[ECO-626] adds an optional filter to the DataTable component which is used to filter out ballots on the Blocks tab.
Also made amendment to the smart-contract Makefile to allow me to get the dev setup completed.

### Which JIRA ticket does this PR relate to?

[ECO-626](https://casperlabs.atlassian.net/browse/ECO-626?atlOrigin=eyJpIjoiNWIwNzg2MWM0OTJlNGMxNWJmYTFjMjAxMTM4ZTUzNjciLCJwIjoiaiJ9)

### Complete this checklist before you submit this PR

- [x] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes

_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._


[ECO-626]: https://casperlabs.atlassian.net/browse/ECO-626