### PR TITLE
[ECO-595]: Download the keys from Clarity in PEM format

### DIFF
--- a/packages/sdk/src/lib/Keys.ts
+++ b/packages/sdk/src/lib/Keys.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as nacl from 'tweetnacl-ts';
 import { decodeBase64 } from 'tweetnacl-util';
-import { ByteArray } from '../index';
+import { ByteArray, encodeBase64 } from '../index';
 import { byteHash } from './Contracts';
 
 // Based on Keys.scala
@@ -129,5 +129,32 @@ export class Ed25519 {
       throw Error(`Unexpected key length: ${len}`);
     }
     return key;
+  }
+
+  static privateKeyEncodeInPem(privateKey: ByteArray) {
+    // prettier-ignore
+    const derPrefix = Buffer.from([48, 46, 2, 1, 0, 48, 5, 6, 3, 43, 101, 112, 4, 34, 4, 32]);
+    const encoded = encodeBase64(
+      Buffer.concat([
+        derPrefix,
+        Buffer.from(Ed25519.parsePrivateKey(privateKey))
+      ])
+    );
+    return (
+      '-----BEGIN PRIVATE KEY-----\n' +
+      encoded +
+      '\n-----END PRIVATE KEY-----\n'
+    );
+  }
+
+  static publicKeyEncodeInPem(publicKey: ByteArray) {
+    // prettier-ignore
+    const derPrefix = Buffer.from([48, 42, 48, 5, 6, 3, 43, 101, 112, 3, 33, 0] );
+    const encoded = encodeBase64(
+      Buffer.concat([derPrefix, Buffer.from(publicKey)])
+    );
+    return (
+      '-----BEGIN PUBLIC KEY-----\n' + encoded + '\n-----END PUBLIC KEY-----\n'
+    );
   }
 }

--- a/packages/sdk/test/lib/Keys.test.ts
+++ b/packages/sdk/test/lib/Keys.test.ts
@@ -2,6 +2,13 @@ import { expect } from 'chai';
 import { decodeBase16 } from '../../src';
 import { Ed25519 } from '../../src/lib/Keys';
 import { byteHash } from '../../src/lib/Contracts';
+import { encodeBase64 } from 'tweetnacl-ts';
+import * as nacl from 'tweetnacl-ts';
+
+import * as fs from 'fs';
+import * as Crypto from 'crypto';
+import * as path from 'path';
+import * as os from 'os';
 
 describe('Ed25519', () => {
   it('calculates the account hash', () => {
@@ -12,5 +19,62 @@ describe('Ed25519', () => {
     const hash = byteHash(bytes);
 
     expect(Ed25519.publicKeyHash(signKeyPair.publicKey)).deep.equal(hash);
+  });
+
+  it('should generate PEM file for Ed25519 correct', () => {
+    const naclKeyPair = Ed25519.newKeyPair();
+    const publicKeyInPem = Ed25519.publicKeyEncodeInPem(naclKeyPair.publicKey);
+    const privateKeyInPem = Ed25519.privateKeyEncodeInPem(
+      naclKeyPair.secretKey
+    );
+
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-'));
+    fs.writeFileSync(tempDir + '/public.pem', publicKeyInPem);
+    fs.writeFileSync(tempDir + '/private.pem', privateKeyInPem);
+    const signKeyPair2 = Ed25519.parseKeyFiles(
+      tempDir + '/public.pem',
+      tempDir + '/private.pem'
+    );
+
+    // expect nacl could import the generated PEM
+    expect(encodeBase64(naclKeyPair.publicKey)).to.equal(
+      encodeBase64(signKeyPair2.publicKey)
+    );
+    expect(encodeBase64(naclKeyPair.secretKey)).to.equal(
+      encodeBase64(signKeyPair2.secretKey)
+    );
+
+    // import pem file to nodejs std library
+    const pubKeyImported = Crypto.createPublicKey(publicKeyInPem);
+    const priKeyImported = Crypto.createPrivateKey(privateKeyInPem);
+    expect(pubKeyImported.asymmetricKeyType).to.equal('ed25519');
+
+    // expect nodejs std lib export the same pem.
+    const publicKeyInPemFromNode = pubKeyImported.export({
+      type: 'spki',
+      format: 'pem'
+    });
+    const privateKeyInPemFromNode = priKeyImported.export({
+      type: 'pkcs8',
+      format: 'pem'
+    });
+    expect(publicKeyInPemFromNode).to.equal(publicKeyInPem);
+    expect(privateKeyInPemFromNode).to.equal(privateKeyInPem);
+
+    // expect both of they generate the same signature
+    const message = Buffer.from('hello world');
+    const signatureByNode = Crypto.sign(null, message, priKeyImported);
+    const signatureByNacl = nacl.sign_detached(
+      Buffer.from(message),
+      naclKeyPair.secretKey
+    );
+    expect(encodeBase64(signatureByNode)).to.eq(encodeBase64(signatureByNacl));
+
+    // expect both of they could verify by their own public key
+    expect(Crypto.verify(null, message, pubKeyImported, signatureByNode)).to
+      .true;
+    expect(
+      nacl.sign_detached_verify(message, signatureByNacl, naclKeyPair.publicKey)
+    ).to.true;
   });
 });

--- a/packages/ui/src/containers/AuthContainer.ts
+++ b/packages/ui/src/containers/AuthContainer.ts
@@ -159,8 +159,22 @@ export class AuthContainer {
     let form = this.accountForm!;
     if (form instanceof NewAccountFormData && form.clean()) {
       // Save the private and public keys to disk.
-      saveToFile(form.privateKeyBase64, `${form.name.$}.private.key`);
-      saveToFile(form.publicKeyBase64.$!, `${form.name.$}.public.key`);
+      saveToFile(
+        Keys.Ed25519.privateKeyEncodeInPem(decodeBase64(form.privateKeyBase64)),
+        `${form.name.$}-account-private.pem`
+      );
+      saveToFile(
+        Keys.Ed25519.publicKeyEncodeInPem(
+          decodeBase64(form.publicKeyBase64.$!)
+        ),
+        `${form.name.$}-account-public.pem`
+      );
+      saveToFile(
+        encodeBase16(
+          Keys.Ed25519.publicKeyHash(decodeBase64(form.publicKeyBase64.$!))
+        ),
+        `${form.name.$}-account-id-hex`
+      );
       // Add the public key to the accounts and save it to Auth0.
       await this.addAccount({
         name: form.name.$!,


### PR DESCRIPTION
### Overview
Exporting the real “pem” for downloading, and also exporting account-id-hex.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-595

### Complete this checklist before you submit this PR

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [X] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes

_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
