### PR TITLE
[ECO-551]:  Display in Clarity the name / parameters of the network

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ ENV STATIC_ROOT=/app/packages/ui/build
 ENV PAYMENT_AMOUNT=10000000
 ENV TRANSFER_AMOUNT=1000000000
 ENV GAS_PRICE=10
+# The name display in the header of clarity.
+ENV NETWORK_NAME=TestNet
 # The link to graphql playground, used in Home page of UI.
 ENV UI_GRAPHQL_URL=http://devnet-graphql.casperlabs.io:40403/graphql
 ENV FAUCET_CONTRACT_PATH=/app/contracts/faucet_stored.wasm

--- a/packages/server/.env
+++ b/packages/server/.env
@@ -34,7 +34,7 @@ STATIC_ROOT=../../ui/build
 
 # In production leave this empty to make the UI connect to the nginx reverse proxy.
 # In testing we can point to grpcwebproxy (started in `hack/docker`) which is configured to allow CORS.
-UI_GRPC_URL=https://clarity.casperlabs.io
+UI_GRPC_URL=https://localhost:8443
 
 # The link to graphql playground, used in Home page of UI.
 UI_GRAPHQL_URL=http://localhost:40403/graphql
@@ -42,3 +42,5 @@ UI_GRAPHQL_URL=http://localhost:40403/graphql
 # Set this when in offline mode so the UI can be used with the mock account.
 # It's passed via config.js so I don't accidentally leave it on by commiting.
 AUTH_MOCK_ENABLED=false
+
+NETWORK_NAME=TestNet

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -40,6 +40,7 @@ const paymentAmount = BigInt(process.env.PAYMENT_AMOUNT!);
 const transferAmount = BigInt(process.env.TRANSFER_AMOUNT)!;
 
 const urls = process.env.CASPER_SERVICE_URL!;
+const networkName = process.env.NETWORK_NAME!;
 
 const nodeUrls = urls
   .split(';')
@@ -97,6 +98,9 @@ app.get('/config.js', (_, res) => {
       mock: {
         enabled: isMock
       }
+    },
+    network: {
+      name: networkName
     },
     grpc: {
       // In production we can leave this empty and then it should

--- a/packages/ui/src/@types/config.d.ts
+++ b/packages/ui/src/@types/config.d.ts
@@ -10,6 +10,9 @@ interface Config {
   graphql: {
     url?: string;
   };
+  network: {
+    name?: string;
+  };
   auth: {
     mock: {
       enabled: boolean;

--- a/packages/ui/src/components/App.tsx
+++ b/packages/ui/src/components/App.tsx
@@ -243,11 +243,11 @@ class _Navigation extends RefreshableComponent<
   AppProps & RouteComponentProps<any>,
   {}
 > {
+  // refresh every 10 seconds
+  refreshIntervalMillis = 10000;
   async refresh() {
-    if (!this.props.connectedPeersContainer.peers?.length) {
-      this.props.connectedPeersContainer.refreshPeers();
-    }
-    this.props.networkInfoContainer.networkInfo();
+    this.props.connectedPeersContainer.refreshPeers();
+    this.props.networkInfoContainer.refresh();
   }
   render() {
     return (

--- a/packages/ui/src/components/App.tsx
+++ b/packages/ui/src/components/App.tsx
@@ -12,7 +12,7 @@ import Accounts from './Accounts';
 import Faucet from './Faucet';
 import Explorer from './Explorer';
 import BlockList from './BlockList';
-import { PrivateRoute, Title } from './Utils';
+import { PrivateRoute, RefreshableComponent, Title } from './Utils';
 import AuthContainer from '../containers/AuthContainer';
 import FaucetContainer from '../containers/FaucetContainer';
 import ErrorContainer from '../containers/ErrorContainer';
@@ -37,6 +37,7 @@ import { useEffect } from 'react';
 import ReactGA from 'react-ga';
 import Validators from './Validators';
 import ValidatorsContainer from '../containers/ValidatorsContainer';
+import { NetworkInfoContainer } from '../containers/NetworkInfoContainer';
 
 // https://medium.com/@pshrmn/a-simple-react-router-v4-tutorial-7f23ff27adf
 
@@ -124,6 +125,7 @@ export interface AppProps {
   connectedPeersContainer: ConnectedPeersContainer;
   search: SearchContainer;
   deployContractsContainer: DeployContractsContainer;
+  networkInfoContainer: NetworkInfoContainer;
 }
 
 // The entry point for rendering.
@@ -189,14 +191,12 @@ export default class App extends React.Component<AppProps, {}> {
     $(document).on('click', 'a.scroll-to-top', function (e) {
       var anchor = $(this);
       var offset = $(anchor.attr('href')!).offset()!;
-      $('html, body')
-        .stop()
-        .animate(
-          {
-            scrollTop: offset.top
-          },
-          1000
-        );
+      $('html, body').stop().animate(
+        {
+          scrollTop: offset.top
+        },
+        1000
+      );
       e.preventDefault();
     });
   }
@@ -239,10 +239,16 @@ const NavLink = (props: { item: MenuItem }) => {
 // https://github.com/mobxjs/mobx-react/issues/274
 // Moved `withRouter` to a separate line.
 @observer
-class _Navigation extends React.Component<
+class _Navigation extends RefreshableComponent<
   AppProps & RouteComponentProps<any>,
   {}
 > {
+  async refresh() {
+    if (!this.props.connectedPeersContainer.peers?.length) {
+      this.props.connectedPeersContainer.refreshPeers();
+    }
+    this.props.networkInfoContainer.networkInfo();
+  }
   render() {
     return (
       <nav
@@ -252,6 +258,30 @@ class _Navigation extends React.Component<
         <a className="navbar-brand" href="https://casperlabs.io/">
           <img src={logo} alt="logo" />
         </a>
+        <div className="navbar-network-info d-none d-md-inline-block">
+          <p>
+            Connected to:&nbsp;
+            <span className={'navbar-network-highlight'}>
+              {window.config?.network?.name}&nbsp;
+            </span>
+            Validators count:&nbsp;
+            <span className={'navbar-network-highlight'}>
+              {this.props.networkInfoContainer.validatorSize}&nbsp;
+            </span>
+            Main rank:&nbsp;
+            <span className={'navbar-network-highlight'}>
+              {this.props.networkInfoContainer.mainRank}&nbsp;
+            </span>
+          </p>
+          {this.props.connectedPeersContainer.peers?.length && (
+            <p>
+              Node version:&nbsp;
+              <span className={'navbar-network-highlight'}>
+                {this.props.connectedPeersContainer.peers[0].getNodeVersion()}
+              </span>
+            </p>
+          )}
+        </div>
         <button
           className="navbar-toggler navbar-toggler-right"
           type="button"

--- a/packages/ui/src/containers/NetworkInfoContainer.ts
+++ b/packages/ui/src/containers/NetworkInfoContainer.ts
@@ -1,0 +1,23 @@
+import ErrorContainer from './ErrorContainer';
+import { CasperService } from 'casperlabs-sdk';
+import { observable } from 'mobx';
+
+export class NetworkInfoContainer {
+  @observable validatorSize: number = 0;
+  @observable mainRank: number = 0;
+  constructor(
+    private errors: ErrorContainer,
+    private casperService: CasperService
+  ) {}
+
+  async networkInfo() {
+    const latestFinalizedBlock = await this.casperService.getLastFinalizedBlockInfo();
+    this.validatorSize = latestFinalizedBlock
+      .getSummary()!
+      .getHeader()!
+      .getState()!
+      .getBondsList()!.length;
+    const lastBlock = await this.casperService.getLatestBlockInfo();
+    this.mainRank = lastBlock.getSummary()!.getHeader()!.getMainRank();
+  }
+}

--- a/packages/ui/src/containers/NetworkInfoContainer.ts
+++ b/packages/ui/src/containers/NetworkInfoContainer.ts
@@ -10,7 +10,7 @@ export class NetworkInfoContainer {
     private casperService: CasperService
   ) {}
 
-  async networkInfo() {
+  async refresh() {
     const latestFinalizedBlock = await this.casperService.getLastFinalizedBlockInfo();
     this.validatorSize = latestFinalizedBlock
       .getSummary()!

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -30,6 +30,7 @@ import ConnectedPeersContainer from './containers/ConnectedPeersContainer';
 import { VestingContainer } from './contracts/Vesting/container/VestingContainer';
 import { DeployContractsContainer } from './containers/DeployContractsContainer';
 import ValidatorsContainer from './containers/ValidatorsContainer';
+import { NetworkInfoContainer } from './containers/NetworkInfoContainer';
 
 let w = window as any;
 w.$ = w.jQuery = jQuery;
@@ -78,6 +79,7 @@ const deployContractsContainer = new DeployContractsContainer(
   casperService
 );
 const validatorsContainer = new ValidatorsContainer(errors, casperService);
+const networkInfoContainer = new NetworkInfoContainer(errors, casperService);
 
 ReactDOM.render(
   <HashRouter>
@@ -95,6 +97,7 @@ ReactDOM.render(
       connectedPeersContainer={connectedPeersContainer}
       search={search}
       deployContractsContainer={deployContractsContainer}
+      networkInfoContainer={networkInfoContainer}
     />
   </HashRouter>,
   document.getElementById('root')

--- a/packages/ui/src/styles/custom.scss
+++ b/packages/ui/src/styles/custom.scss
@@ -128,3 +128,22 @@ footer.sticky-footer {
 .navbar-nav.ml-auto > .nav-item:last-child {
   margin-right: 33px !important;
 }
+
+.navbar-network-info {
+  width: 633px;
+  height: 65px;
+  background: #232323 0% 0% no-repeat padding-box;
+  border-radius: 4px;
+  opacity: 1;
+  padding: 13px 19px;
+  p {
+    text-align: left;
+    font: normal normal normal 15px/19px Sarabun;
+    letter-spacing: 0px;
+    color: #868e96;
+    margin: 0;
+  }
+  .navbar-network-highlight {
+    color: #ffffff;
+  }
+}


### PR DESCRIPTION
### Overview
As the title said. And we display the main rank instead of block number. 

Preview: 
![image](https://user-images.githubusercontent.com/7604540/92402434-2189f600-f162-11ea-8dee-a64dd92cb5a8.png)

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-551

### Complete this checklist before you submit this PR

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [X] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes

_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
