### PR TITLE
[ECO-719] Clarity prevents token funding requests until faucet contract is found in Global State

### DIFF
--- a/packages/server/src/StoredFaucetService.ts
+++ b/packages/server/src/StoredFaucetService.ts
@@ -1,5 +1,4 @@
 import {
-  Contracts,
   DeployHash,
   encodeBase16,
   Keys,
@@ -8,88 +7,50 @@ import {
   DeployUtil
 } from 'casperlabs-sdk';
 import { ByteArray, SignKeyPair } from 'tweetnacl-ts';
-import { CallFaucet, StoredFaucet } from './lib/Contracts';
+import { CallFaucet } from './lib/Contracts';
 
 // based on execution-engine/contracts/explorer/faucet-stored/src/main.rs
 const CONTRACT_NAME = 'faucet';
 const ENTRY_POINT_NAME = 'call_faucet';
 
 export class StoredFaucetService {
-  private deployHash: ByteArray | null = null;
-
-  // indicate whether the deploy of the stored version Faucet has been finalized,
-  // if finalized, we no longer need set dependencies when calling stored version contract
-  private storedFaucetFinalized: boolean = false;
-
   constructor(
-    private faucetContract: Contracts.BoundContract,
     private contractKeys: SignKeyPair,
     private paymentAmount: bigint,
     private transferAmount: bigint,
     private casperService: CasperServiceByJsonRPC,
     private chainName: string
-  ) {
-    this.periodCheckState().then();
-  }
+  ) {}
 
   async callStoredFaucet(accountPublicKeyHash: ByteArray): Promise<DeployHash> {
-    if (!this.storedFaucetFinalized && !this.deployHash) {
-      const state = await this.checkState();
-      if (state) {
-        this.storedFaucetFinalized = true;
-      } else {
-        const deploy = this.faucetContract.deploy(
-          StoredFaucet.args(),
-          this.paymentAmount,
-          this.chainName
-        );
-        await this.casperService.deploy(deploy).catch(err => {
-          console.error(err);
-        });
-        this.deployHash = deploy.hash;
-      }
+    const state = await this.checkState();
+    if (state) {
+      const sessionArgs = CallFaucet.args(
+        accountPublicKeyHash,
+        this.transferAmount
+      ).toBytes();
+      const session = new DeployUtil.StoredContractByName(
+        CONTRACT_NAME,
+        ENTRY_POINT_NAME,
+        sessionArgs
+      );
+
+      const payment = DeployUtil.standardPayment(this.paymentAmount);
+      const deployByName = DeployUtil.makeDeploy(
+        session,
+        payment,
+        PublicKey.fromEd25519(this.contractKeys.publicKey),
+        this.chainName
+      );
+      const signedDeploy = DeployUtil.signDeploy(
+        deployByName,
+        this.contractKeys
+      );
+      await this.casperService.deploy(signedDeploy);
+      return signedDeploy.hash;
+    } else {
+      throw new Error("Can't do faucet now");
     }
-
-    const dependencies = [];
-    if (this.deployHash) {
-      dependencies.push(this.deployHash);
-    }
-
-    const sessionArgs = CallFaucet.args(
-      accountPublicKeyHash,
-      this.transferAmount
-    ).toBytes();
-    const session = new DeployUtil.StoredContractByName(
-      CONTRACT_NAME,
-      ENTRY_POINT_NAME,
-      sessionArgs
-    );
-
-    const payment = DeployUtil.standardPayment(this.paymentAmount);
-    const deployByName = DeployUtil.makeDeploy(
-      session,
-      payment,
-      PublicKey.fromEd25519(this.contractKeys.publicKey),
-      this.chainName
-    );
-    const signedDeploy = DeployUtil.signDeploy(deployByName, this.contractKeys);
-    await this.casperService.deploy(signedDeploy);
-    return signedDeploy.hash;
-  }
-
-  /**
-   * Check whether stored version faucet has been finalised every 10 seconds.
-   */
-  private async periodCheckState() {
-    const timeInterval = setInterval(async () => {
-      const state = await this.checkState();
-      if (state) {
-        this.storedFaucetFinalized = true;
-        // we don't need to set dependency anymore
-        this.deployHash = null;
-        clearInterval(timeInterval);
-      }
-    }, 10 * 1000);
   }
 
   /**

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,4 +1,4 @@
-import { CasperServiceByJsonRPC, Contracts, Keys } from 'casperlabs-sdk';
+import { CasperServiceByJsonRPC, Keys } from 'casperlabs-sdk';
 import dotenv from 'dotenv';
 import express from 'express';
 import jwt from 'express-jwt';
@@ -103,12 +103,6 @@ const contractKeys = Keys.Ed25519.parseKeyFiles(
   process.env.FAUCET_ACCOUNT_PRIVATE_KEY_PATH!
 );
 
-// Faucet contract and deploy factory.
-const storedFaucet = new Contracts.BoundContract(
-  new Contracts.Contract(process.env.FAUCET_CONTRACT_PATH!),
-  contractKeys
-);
-
 // Constant payment amount.
 const paymentAmount = BigInt(process.env.PAYMENT_AMOUNT!);
 // How much to send to a user in a faucet request.
@@ -121,7 +115,6 @@ const chainName = process.env.CHAIN_NAME!;
 const jsonRpcUrl = process.env.JSON_RPC_URL!;
 const casperService = new CasperServiceByJsonRPC(jsonRpcUrl);
 const storedFaucetService = new StoredFaucetService(
-  storedFaucet,
   contractKeys,
   paymentAmount,
   transferAmount,


### PR DESCRIPTION
### Overview

SRE team would deploy the stored version contract, and so Clarity don't need to care about it, and prevent token funding requests until the faucet contract is found in Global State

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-719


### Complete this checklist before you submit this PR

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [X] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes

_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
