### PR TITLE
ECO-758 Connect to Signer Button

### DIFF
--- a/packages/ui/src/components/App.tsx
+++ b/packages/ui/src/components/App.tsx
@@ -378,7 +378,10 @@ class _Navigation extends RefreshableComponent<
                 </a>
               )}
             </li>
-            <li className="nav-item">
+            <li
+              className="nav-item"
+              style={{ paddingLeft: '1rem', paddingTop: '.3rem' }}
+            >
               <ConnectButton auth={this.props.auth} />
             </li>
           </ul>

--- a/packages/ui/src/components/App.tsx
+++ b/packages/ui/src/components/App.tsx
@@ -41,6 +41,7 @@ import ValidatorsContainer from '../containers/ValidatorsContainer';
 import { NetworkInfoContainer } from '../containers/NetworkInfoContainer';
 import FaucetAsterix from '../img/faucet-asterix.svg';
 import { Signer } from 'casperlabs-sdk';
+import ConnectButton from './ConnectButton';
 
 // https://medium.com/@pshrmn/a-simple-react-router-v4-tutorial-7f23ff27adf
 
@@ -377,18 +378,8 @@ class _Navigation extends RefreshableComponent<
                 </a>
               )}
             </li>
-            {/* George: Styling and spacing needs improving here */}
             <li className="nav-item">
-              <Button
-                onClick={() => {
-                  Signer.sendConnectionRequest();
-                }}
-                title={'Connect to Signer'}
-                // Make button state/appearance conditional on connected or not
-                disabled={false}
-                type={'primary'}
-                size={'sm'}
-              />
+              <ConnectButton auth={this.props.auth} />
             </li>
           </ul>
         </div>

--- a/packages/ui/src/components/ConnectButton.tsx
+++ b/packages/ui/src/components/ConnectButton.tsx
@@ -10,7 +10,6 @@ class ConnectButton extends RefreshableComponent<{ auth: AuthContainer }, {}> {
   constructor(props: any) {
     super(props);
     this.refreshIntervalMillis = 1000;
-    var signerError: boolean;
   }
 
   async refresh() {

--- a/packages/ui/src/components/ConnectButton.tsx
+++ b/packages/ui/src/components/ConnectButton.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { observer } from 'mobx-react';
+
+import { Button } from './Utils';
+import { Signer } from 'casperlabs-sdk';
+import AuthContainer from '../containers/AuthContainer';
+
+@observer
+class ConnectButton extends React.Component<{ auth: AuthContainer }, {}> {
+  constructor(props: any) {
+    super(props);
+  }
+
+  renderDisconnected() {
+    return (
+      <Button
+        onClick={() => {
+          Signer.sendConnectionRequest();
+        }}
+        title={'Not Connected'}
+        disabled={false}
+        type={'primary'}
+        size={'sm'}
+      />
+    );
+  }
+
+  renderConnected() {
+    return (
+      <Button
+        onClick={() => {
+          alert('Already connected to Signer');
+        }}
+        title={'Connected'}
+        disabled={true}
+        type={'primary'}
+        size={'sm'}
+      />
+    );
+  }
+
+  render() {
+    return this.props.auth.connectedToSigner
+      ? this.renderConnected()
+      : this.renderDisconnected();
+  }
+}
+
+export default ConnectButton;

--- a/packages/ui/src/components/ConnectButton.tsx
+++ b/packages/ui/src/components/ConnectButton.tsx
@@ -1,23 +1,40 @@
 import React from 'react';
 import { observer } from 'mobx-react';
 
-import { Button } from './Utils';
+import { Button, RefreshableComponent } from './Utils';
 import { Signer } from 'casperlabs-sdk';
 import AuthContainer from '../containers/AuthContainer';
 
 @observer
-class ConnectButton extends React.Component<{ auth: AuthContainer }, {}> {
+class ConnectButton extends RefreshableComponent<{ auth: AuthContainer }, {}> {
   constructor(props: any) {
     super(props);
+    this.refreshIntervalMillis = 1000;
+    var signerError: boolean;
+  }
+
+  async refresh() {
+    try {
+      this.props.auth.connectedToSigner = !!(await Signer?.isConnected());
+    } catch (err) {
+      console.error(err);
+    }
   }
 
   renderDisconnected() {
     return (
       <Button
         onClick={() => {
-          Signer.sendConnectionRequest();
+          try {
+            Signer.sendConnectionRequest();
+          } catch (err) {
+            alert(
+              'Please install the CasperLabs Signer from the Chrome Store:\nhttps://chrome.google.com/webstore/detail/casperlabs-signer/djhndpllfiibmcdbnmaaahkhchcoijce'
+            );
+            console.error(err);
+          }
         }}
-        title={'Not Connected'}
+        title={'Connect to Signer'}
         disabled={false}
         type={'primary'}
         size={'sm'}
@@ -31,7 +48,7 @@ class ConnectButton extends React.Component<{ auth: AuthContainer }, {}> {
         onClick={() => {
           alert('Already connected to Signer');
         }}
-        title={'Connected'}
+        title={'Connected to Signer'}
         disabled={true}
         type={'primary'}
         size={'sm'}

--- a/packages/ui/src/components/DeployContracts.tsx
+++ b/packages/ui/src/components/DeployContracts.tsx
@@ -7,7 +7,8 @@ import {
   Icon,
   ListInline,
   Spinner,
-  SuccessIcon
+  SuccessIcon,
+  RefreshableComponent
 } from './Utils';
 import React from 'react';
 import {
@@ -33,7 +34,22 @@ interface Props {
 }
 
 @observer
-export class DeployContractsForm extends React.Component<Props, {}> {
+export class DeployContractsForm extends RefreshableComponent<Props, {}> {
+  constructor(props: Props) {
+    super(props);
+    this.refreshIntervalMillis = 1000;
+  }
+
+  connectedToSigner: boolean;
+
+  async refresh() {
+    try {
+      this.connectedToSigner = !!(await Signer?.isConnected());
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
   private interval: number | null;
 
   componentDidMount(): void {
@@ -53,9 +69,10 @@ export class DeployContractsForm extends React.Component<Props, {}> {
   }
 
   render() {
+    // For some reason refresh() wasn't being called automatically
+    this.refresh();
     const { deployContractsContainer } = this.props;
-    // George-Note: This always succeeds as it doesn't handle the promise result
-    let hint = this.props.deployContractsContainer.checkConnectionToSigner() ? (
+    let hint = this.connectedToSigner ? (
       <p>
         <SuccessIcon /> We will use CasperLabs Signer extension to sign the
         deploy
@@ -63,7 +80,14 @@ export class DeployContractsForm extends React.Component<Props, {}> {
     ) : (
       <p>
         <FailIcon />
-        Please install or connect the CasperLabs Signer extension
+        Please connect to the Signer first. If you don't have it installed you
+        can get it&nbsp;
+        <a
+          href="https://chrome.google.com/webstore/detail/casperlabs-signer/djhndpllfiibmcdbnmaaahkhchcoijce"
+          target="_blank"
+        >
+          here.
+        </a>
       </p>
     );
     let modalAccountForm = (

--- a/packages/ui/src/containers/AuthContainer.ts
+++ b/packages/ui/src/containers/AuthContainer.ts
@@ -10,7 +10,8 @@ import {
   encodeBase64,
   Keys,
   CasperServiceByJsonRPC,
-  BalanceServiceByJsonRPC
+  BalanceServiceByJsonRPC,
+  Signer
 } from 'casperlabs-sdk';
 import ObservableValueMap from '../lib/ObservableValueMap';
 import { FieldState } from 'formstate';
@@ -58,6 +59,8 @@ export class AuthContainer {
   // How often to query balances. Lots of state queries to get one.
   balanceTtl = 5 * 60 * 1000;
 
+  @observable connectedToSigner: boolean;
+
   constructor(
     private errors: ErrorContainer,
     private authService: AuthService,
@@ -78,6 +81,8 @@ export class AuthContainer {
     }
 
     this.fetchUser();
+
+    this.connectedToSigner = !!(await Signer.isConnected());
   }
 
   async login() {

--- a/packages/ui/src/containers/AuthContainer.ts
+++ b/packages/ui/src/containers/AuthContainer.ts
@@ -82,7 +82,11 @@ export class AuthContainer {
 
     this.fetchUser();
 
-    this.connectedToSigner = !!(await Signer.isConnected());
+    try {
+      this.connectedToSigner = !!(await Signer?.isConnected());
+    } catch (err) {
+      console.error(err);
+    }
   }
 
   async login() {

--- a/packages/ui/src/containers/DeployContractsContainer.ts
+++ b/packages/ui/src/containers/DeployContractsContainer.ts
@@ -294,8 +294,13 @@ export class DeployContractsContainer {
   }
 
   async checkConnectionToSigner() {
-    let connected = await Signer.isConnected();
-    return connected;
+    try {
+      let connected = await Signer.isConnected();
+      return connected;
+    } catch (err) {
+      console.error(err);
+      return false;
+    }
   }
 
   @action.bound


### PR DESCRIPTION
### Overview
This makes the button for connecting to the Signer from Clarity reactive to the connection state - disabling when connected and changing text:
![Screenshot from 2020-11-15 18-25-52](https://user-images.githubusercontent.com/69711689/99193304-0cd46a80-2770-11eb-8820-beacef6777bc.png)


It also adds links to the plugin's web store page in the alerts when users attempt to use it without first installing it:

![Screenshot from 2020-11-15 18-21-32](https://user-images.githubusercontent.com/69711689/99193220-83249d00-276f-11eb-8d80-74d73412f3fb.png)


### Which JIRA ticket does this PR relate to?

[ECO-758](https://casperlabs.atlassian.net/browse/ECO-758?atlOrigin=eyJpIjoiY2FiMzM4MzkwOGFhNDk1N2E1YTMwNWM2MjZlMDdlZWUiLCJwIjoiaiJ9)

### Complete this checklist before you submit this PR

- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes

There is an issue with the DeployContractsForm not refreshing automatically, but I can't see why as yet so I have called the refresh() method explicitly prior to render(). This should be improved in future.
