### PR TITLE
ECO-771: deal with different line-ending when importing pem files

### DIFF
--- a/packages/sdk/src/lib/Keys.ts
+++ b/packages/sdk/src/lib/Keys.ts
@@ -1,9 +1,9 @@
 import * as fs from 'fs';
 import * as nacl from 'tweetnacl-ts';
+import { SignKeyPair } from 'tweetnacl-ts';
 import { decodeBase64 } from 'tweetnacl-util';
 import { ByteArray, encodeBase16, encodeBase64, PublicKey } from '../index';
 import { byteHash } from './Contracts';
-import { SignKeyPair } from 'tweetnacl-ts';
 
 export enum SignatureAlgorithm {
   Ed25519 = 'ed25519'
@@ -133,20 +133,23 @@ export class Ed25519 extends AsymmetricKey {
    * Example PEM:
    *
    * ```
-   * -----BEGIN PUBLIC KEY-----
-   * MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEj1fgdbpNbt06EY/8C+wbBXq6VvG+vCVD
-   * Nl74LvVAmXfpdzCWFKbdrnIlX3EFDxkd9qpk35F/kLcqV3rDn/u3dg==
-   * -----END PUBLIC KEY-----
+   * -----BEGIN PUBLIC KEY-----\r\n
+   * MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEj1fgdbpNbt06EY/8C+wbBXq6VvG+vCVD\r\n
+   * Nl74LvVAmXfpdzCWFKbdrnIlX3EFDxkd9qpk35F/kLcqV3rDn/u3dg==\r\n
+   * -----END PUBLIC KEY-----\r\n
    * ```
    *
    */
   public static readBase64WithPEM(content: string): ByteArray {
     const base64 = content
-      .split('\n')
+      // there are two kinks of line-endings, CRLF(\r\n) and LF(\n)
+      // we need handle both
+      .split(/\r?\n/)
       .filter(x => !x.startsWith('---'))
-      .join('');
-    const bytes = decodeBase64(base64);
-    return bytes;
+      .join('')
+      // remove the line-endings in the end of content
+      .trim();
+    return decodeBase64(base64);
   }
 
   /**

--- a/packages/sdk/test/lib/Keys.test.ts
+++ b/packages/sdk/test/lib/Keys.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { decodeBase16 } from '../../src';
+import { decodeBase16, decodeBase64 } from '../../src';
 import { Ed25519 } from '../../src/lib/Keys';
 import { byteHash } from '../../src/lib/Contracts';
 import { encodeBase64 } from 'tweetnacl-ts';
@@ -85,5 +85,23 @@ describe('Ed25519', () => {
         naclKeyPair.publicKey.rawPublicKey
       )
     ).to.true;
+  });
+
+  it('should deal with different line-endings', () => {
+    const keyWithoutPem =
+      'MCowBQYDK2VwAyEA4PFXL2NuakBv3l7yrDg65HaYQtxKR+SCRTDI+lXBoM8=';
+    const key1 = decodeBase64(keyWithoutPem);
+    const keyWithLF =
+      '-----BEGIN PUBLIC KEY-----\n' +
+      'MCowBQYDK2VwAyEA4PFXL2NuakBv3l7yrDg65HaYQtxKR+SCRTDI+lXBoM8=\n' +
+      '-----END PUBLIC KEY-----\n';
+    const key2 = Ed25519.readBase64WithPEM(keyWithLF);
+    expect(key2).to.deep.eq(key1);
+    const keyWithCRLF =
+      '-----BEGIN PUBLIC KEY-----\r\n' +
+      'MCowBQYDK2VwAyEA4PFXL2NuakBv3l7yrDg65HaYQtxKR+SCRTDI+lXBoM8=\r\n' +
+      '-----END PUBLIC KEY-----\r\n';
+    const key3 = Ed25519.readBase64WithPEM(keyWithCRLF);
+    expect(key3).to.deep.eq(key1);
   });
 });


### PR DESCRIPTION
### Overview

There are two kinks of line-endings, CRLF(\r\n) and LF(\n), we have to handle both. For details see the added unit test.


### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-771

### Complete this checklist before you submit this PR

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes

_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
