### PR TITLE
Remove Auth0 from Deploy Contract tab.

### DIFF
--- a/packages/ui/src/components/App.tsx
+++ b/packages/ui/src/components/App.tsx
@@ -487,10 +487,10 @@ const Content = (props: AppProps) => {
               <Title title="Deploy Detail" />
               <DeployDetails {...props} />
             </Route>
-            <PrivateRoute path={Pages.DeployContracts} auth={props.auth}>
+            <Route path={Pages.DeployContracts}>
               <Title title="Deploy Contract" />
               <DeployContractsForm {...props} />
-            </PrivateRoute>
+            </Route>
             <Route path={Pages.Deploys}>
               <Title title={'Deploys'} />
               <AccountSelector {...props} />


### PR DESCRIPTION
### Overview

Remove Auth0 from Deploy Contract tab, as it uses only Signer when sending deploys.