### PR TITLE
[No-Ticket] rename getter related methods and private key with secret key

### DIFF
--- a/packages/sdk/src/lib/CasperClient.ts
+++ b/packages/sdk/src/lib/CasperClient.ts
@@ -43,7 +43,7 @@ export class CasperClient {
   }
 
   /**
-   * Load private key from file
+   * Load public key from file
    *
    * @param path the path to the publicKey file
    * @param algo the signature algorithm of the file
@@ -63,8 +63,8 @@ export class CasperClient {
   }
 
   /**
-   * Load private key
-   * @param path the path to the private key file
+   * Load secret key
+   * @param path the path to the secret key file
    */
   public getSecretKeyFromPEMFile(
     path: string,
@@ -81,9 +81,9 @@ export class CasperClient {
   }
 
   /**
-   * Load private key file to restore keyPair
+   * Load secret key file to restore keyPair
    *
-   * @param path The path to the private key
+   * @param path The path to the secret key
    * @param algo
    */
   public getKeyPairFromSecretPEMFile(
@@ -110,18 +110,18 @@ export class CasperClient {
   }
 
   /**
-   * Compute public key from private Key.
-   * @param privateKey
+   * Compute public key from secret Key.
+   * @param secretKey
    */
-  public privateToPublicKey(
-    privateKey: ByteArray,
+  public getPublicKeyFromSecretKey(
+    secretKey: ByteArray,
     algo: SignatureAlgorithm
   ): ByteArray {
     switch (algo) {
       case SignatureAlgorithm.Ed25519:
-        return Keys.Ed25519.getPublicKeyFromSecretKey(privateKey);
+        return Keys.Ed25519.getPublicKeyFromSecretKey(secretKey);
       case SignatureAlgorithm.Secp256K1:
-        return Keys.Secp256K1.getPublicKeyFromSecretKey(privateKey);
+        return Keys.Secp256K1.getPublicKeyFromSecretKey(secretKey);
       default:
         throw new Error('Invalid signature algorithm');
     }

--- a/packages/sdk/src/lib/CasperClient.ts
+++ b/packages/sdk/src/lib/CasperClient.ts
@@ -31,7 +31,7 @@ export class CasperClient {
    * Generate new key pair.
    * @param algo Currently we support Ed25519 and Secp256K1.
    */
-  public newKeyPair(algo: SignatureAlgorithm): AsymmetricKey {
+  public getKeyPair(algo: SignatureAlgorithm): AsymmetricKey {
     switch (algo) {
       case SignatureAlgorithm.Ed25519:
         return Keys.Ed25519.new();
@@ -48,15 +48,15 @@ export class CasperClient {
    * @param path the path to the publicKey file
    * @param algo the signature algorithm of the file
    */
-  public loadPublicKeyFromFile(
+  public getPublicKeyFromPEMFile(
     path: string,
     algo: SignatureAlgorithm
   ): ByteArray {
     switch (algo) {
       case SignatureAlgorithm.Ed25519:
-        return Keys.Ed25519.parsePublicKeyFile(path);
+        return Keys.Ed25519.getPublicKeyFromPEMFile(path);
       case SignatureAlgorithm.Secp256K1:
-        return Keys.Secp256K1.parsePublicKeyFile(path);
+        return Keys.Secp256K1.getPublicKeyFromPEMFile(path);
       default:
         throw new Error('Invalid signature algorithm');
     }
@@ -66,15 +66,15 @@ export class CasperClient {
    * Load private key
    * @param path the path to the private key file
    */
-  public loadPrivateKeyFromFile(
+  public getSecretKeyFromPEMFile(
     path: string,
     algo: SignatureAlgorithm
   ): ByteArray {
     switch (algo) {
       case SignatureAlgorithm.Ed25519:
-        return Keys.Ed25519.parsePrivateKeyFile(path);
+        return Keys.Ed25519.getSecretKeyFromPEMFile(path);
       case SignatureAlgorithm.Secp256K1:
-        return Keys.Secp256K1.parsePrivateKeyFile(path);
+        return Keys.Secp256K1.getSecretKeyFromPEMFile(path);
       default:
         throw new Error('Invalid signature algorithm');
     }
@@ -86,15 +86,15 @@ export class CasperClient {
    * @param path The path to the private key
    * @param algo
    */
-  public loadKeyPairFromPrivateFile(
+  public getKeyPairFromSecretPEMFile(
     path: string,
     algo: SignatureAlgorithm
   ): AsymmetricKey {
     switch (algo) {
       case SignatureAlgorithm.Ed25519:
-        return Keys.Ed25519.loadKeyPairFromPrivateFile(path);
+        return Keys.Ed25519.getKeyPairFromSecretPEMFile(path);
       case SignatureAlgorithm.Secp256K1:
-        return Keys.Secp256K1.loadKeyPairFromPrivateFile(path);
+        return Keys.Secp256K1.getKeyPairFromSecretPEMFile(path);
       default:
         throw new Error('Invalid signature algorithm');
     }
@@ -105,7 +105,7 @@ export class CasperClient {
    *
    * @param seed The seed buffer for parent key
    */
-  public newHdWallet(seed: ByteArray): CasperHDKey {
+  public getWalletFromSeed(seed: ByteArray): CasperHDKey {
     return CasperHDKey.fromMasterSeed(seed);
   }
 
@@ -119,9 +119,9 @@ export class CasperClient {
   ): ByteArray {
     switch (algo) {
       case SignatureAlgorithm.Ed25519:
-        return Keys.Ed25519.privateToPublicKey(privateKey);
+        return Keys.Ed25519.getPublicKeyFromSecretKey(privateKey);
       case SignatureAlgorithm.Secp256K1:
-        return Keys.Secp256K1.privateToPublicKey(privateKey);
+        return Keys.Secp256K1.getPublicKeyFromSecretKey(privateKey);
       default:
         throw new Error('Invalid signature algorithm');
     }
@@ -163,8 +163,8 @@ export class CasperClient {
    * convert the deploy object to json
    * @param deploy
    */
-  public deployToJson(deploy: Deploy) {
-    return DeployUtil.deployToJson(deploy);
+  public getDeployAsJSON(deploy: Deploy) {
+    return DeployUtil.getDeployAsJSON(deploy);
   }
 
   /**
@@ -185,14 +185,18 @@ export class CasperClient {
   /**
    * Get the balance of public key
    */
-  public async balanceOfByPublicKey(publicKey: PublicKey): Promise<number> {
-    return this.balanceOfByAccountHash(encodeBase16(publicKey.toAccountHash()));
+  public async getBalanceOfByPublicKey(publicKey: PublicKey): Promise<number> {
+    return this.getBalanceOfByAccountHash(
+      encodeBase16(publicKey.toAccountHash())
+    );
   }
 
   /**
    * Get the balance by account hash
    */
-  public async balanceOfByAccountHash(accountHashStr: string): Promise<number> {
+  public async getBalanceOfByAccountHash(
+    accountHashStr: string
+  ): Promise<number> {
     try {
       const stateRootHash = await this.nodeClient
         .getLatestBlockInfo()
@@ -225,7 +229,7 @@ export class CasperClient {
    * @param page
    * @param limit
    */
-  public async getAccountsDeploys(
+  public async getAccountDeploys(
     publicKey: PublicKey,
     page: number = 0,
     limit: number = 20

--- a/packages/sdk/src/lib/CasperHDKey.ts
+++ b/packages/sdk/src/lib/CasperHDKey.ts
@@ -34,11 +34,11 @@ export class CasperHDKey {
     return this.hdKey.publicKey;
   }
 
-  public privateKey() {
+  public secretKey() {
     return this.hdKey.privateKey;
   }
 
-  public privateExtendedKey() {
+  public secretExtendedKey() {
     return this.hdKey.privateExtendedKey;
   }
 

--- a/packages/sdk/src/lib/DeployUtil.ts
+++ b/packages/sdk/src/lib/DeployUtil.ts
@@ -480,8 +480,8 @@ export const signDeploy = (
 ): Deploy => {
   const approval = new Approval();
   const signature = signingKey.sign(deploy.hash);
-  approval.signer = signingKey.accountHex();
-  approval.signature = Keys.Ed25519.accountHex(signature);
+  approval.signer = signingKey.getAccountHex();
+  approval.signature = Keys.Ed25519.getAccountHex(signature);
   deploy.approvals.push(approval);
 
   return deploy;
@@ -524,7 +524,7 @@ export const standardPayment = (paymentAmount: bigint | JSBI) => {
  *
  * @param deploy
  */
-export const deployToJson = (deploy: Deploy) => {
+export const getDeployAsJSON = (deploy: Deploy) => {
   const header = deploy.header;
   const headerJson = {
     account: header.account.toAccountHex(),

--- a/packages/sdk/src/lib/Keys.ts
+++ b/packages/sdk/src/lib/Keys.ts
@@ -82,14 +82,14 @@ export abstract class AsymmetricKey {
   /**
    * Compute a unique hash from the algorithm name(Ed25519 here) and a public key, used for accounts.
    */
-  public accountHash(): ByteArray {
+  public getAccountHash(): ByteArray {
     return this.publicKey.toAccountHash();
   }
 
   /**
    * Get the account hex
    */
-  public accountHex(): string {
+  public getAccountHex(): string {
     return this.publicKey.toAccountHex();
   }
 
@@ -141,7 +141,7 @@ export class Ed25519 extends AsymmetricKey {
    * Generate the accountHex for the Ed25519 public key
    * @param publicKey
    */
-  public static accountHex(publicKey: ByteArray): string {
+  public static getAccountHex(publicKey: ByteArray): string {
     return '01' + encodeBase16(publicKey);
   }
 
@@ -150,12 +150,12 @@ export class Ed25519 extends AsymmetricKey {
    * @param publicKeyPath path of public key file
    * @param privateKeyPath path of private key file
    */
-  public static parseKeyFiles(
+  public static getKeyPairFromFiles(
     publicKeyPath: string,
     privateKeyPath: string
   ): AsymmetricKey {
-    const publicKey = Ed25519.parsePublicKeyFile(publicKeyPath);
-    const privateKey = Ed25519.parsePrivateKeyFile(privateKeyPath);
+    const publicKey = Ed25519.getPublicKeyFromPEMFile(publicKeyPath);
+    const privateKey = Ed25519.getSecretKeyFromPEMFile(privateKeyPath);
     // nacl expects that the private key will contain both.
     return new Ed25519({
       publicKey,
@@ -167,7 +167,7 @@ export class Ed25519 extends AsymmetricKey {
    * Generate the accountHash for the Ed25519 public key
    * @param publicKey
    */
-  public static accountHash(publicKey: ByteArray): ByteArray {
+  public static getAccountHashFromPublicKey(publicKey: ByteArray): ByteArray {
     return accountHashHelper(SignatureAlgorithm.Ed25519, publicKey);
   }
 
@@ -176,7 +176,7 @@ export class Ed25519 extends AsymmetricKey {
    * @param publicKey
    * @param privateKey
    */
-  public static parseKeyPair(
+  public static getKeyPairFromBytes(
     publicKey: ByteArray,
     privateKey: ByteArray
   ): AsymmetricKey {
@@ -189,11 +189,11 @@ export class Ed25519 extends AsymmetricKey {
     });
   }
 
-  public static parsePrivateKeyFile(path: string): ByteArray {
+  public static getSecretKeyFromPEMFile(path: string): ByteArray {
     return Ed25519.parsePrivateKey(Ed25519.readBase64File(path));
   }
 
-  public static parsePublicKeyFile(path: string): ByteArray {
+  public static getPublicKeyFromPEMFile(path: string): ByteArray {
     return Ed25519.parsePublicKey(Ed25519.readBase64File(path));
   }
 
@@ -285,7 +285,7 @@ export class Ed25519 extends AsymmetricKey {
    * Derive public key from private key
    * @param privateKey
    */
-  public static privateToPublicKey(privateKey: ByteArray) {
+  public static getPublicKeyFromSecretKey(privateKey: ByteArray) {
     if (privateKey.length === SignLength.SecretKey) {
       return nacl.sign_keyPair_fromSecretKey(privateKey).publicKey;
     } else {
@@ -297,10 +297,10 @@ export class Ed25519 extends AsymmetricKey {
    * Restore Ed25519 keyPair from private key file
    * @param privateKeyPath
    */
-  public static loadKeyPairFromPrivateFile(privateKeyPath: string) {
-    const privateKey = Ed25519.parsePrivateKeyFile(privateKeyPath);
-    const publicKey = Ed25519.privateToPublicKey(privateKey);
-    return Ed25519.parseKeyPair(publicKey, privateKey);
+  public static getKeyPairFromSecretPEMFile(privateKeyPath: string) {
+    const privateKey = Ed25519.getSecretKeyFromPEMFile(privateKeyPath);
+    const publicKey = Ed25519.getPublicKeyFromSecretKey(privateKey);
+    return Ed25519.getKeyPairFromBytes(publicKey, privateKey);
   }
 }
 
@@ -324,12 +324,12 @@ export class Secp256K1 extends AsymmetricKey {
    * @param publicKeyPath path of public key file
    * @param privateKeyPath path of private key file
    */
-  public static parseKeyFiles(
+  public static getKeyPairFromFiles(
     publicKeyPath: string,
     privateKeyPath: string
   ): AsymmetricKey {
-    const publicKey = Secp256K1.parsePublicKeyFile(publicKeyPath);
-    const privateKey = Secp256K1.parsePrivateKeyFile(privateKeyPath);
+    const publicKey = Secp256K1.getPublicKeyFromPEMFile(publicKeyPath);
+    const privateKey = Secp256K1.getSecretKeyFromPEMFile(privateKeyPath);
     return new Secp256K1(publicKey, privateKey);
   }
 
@@ -337,7 +337,7 @@ export class Secp256K1 extends AsymmetricKey {
    * Generate the accountHash for the Secp256K1 public key
    * @param publicKey
    */
-  public static accountHash(publicKey: ByteArray): ByteArray {
+  public static getAccountHash(publicKey: ByteArray): ByteArray {
     return accountHashHelper(SignatureAlgorithm.Secp256K1, publicKey);
   }
 
@@ -347,7 +347,7 @@ export class Secp256K1 extends AsymmetricKey {
    * @param privateKey
    * @param originalFormat the format of the public/private key
    */
-  public static parseKeyPair(
+  public static getKeyPairFromBytes(
     publicKey: ByteArray,
     privateKey: ByteArray,
     originalFormat: 'raw' | 'der'
@@ -358,11 +358,11 @@ export class Secp256K1 extends AsymmetricKey {
     return new Secp256K1(publ, priv);
   }
 
-  public static parsePrivateKeyFile(path: string): ByteArray {
+  public static getSecretKeyFromPEMFile(path: string): ByteArray {
     return Secp256K1.parsePrivateKey(Secp256K1.readBase64File(path));
   }
 
-  public static parsePublicKeyFile(path: string): ByteArray {
+  public static getPublicKeyFromPEMFile(path: string): ByteArray {
     return Secp256K1.parsePublicKey(Secp256K1.readBase64File(path));
   }
 
@@ -462,7 +462,7 @@ export class Secp256K1 extends AsymmetricKey {
    * Derive public key from private key
    * @param privateKey
    */
-  public static privateToPublicKey(privateKey: ByteArray): ByteArray {
+  public static getPublicKeyFromSecretKey(privateKey: ByteArray): ByteArray {
     return secp256k1.publicKeyCreate(privateKey, true);
   }
 
@@ -470,10 +470,10 @@ export class Secp256K1 extends AsymmetricKey {
    * Restore Secp256K1 keyPair from private key file
    * @param privateKeyPath a path to file of the private key
    */
-  public static loadKeyPairFromPrivateFile(privateKeyPath: string) {
-    const privateKey = Secp256K1.parsePrivateKeyFile(privateKeyPath);
-    const publicKey = Secp256K1.privateToPublicKey(privateKey);
-    return Secp256K1.parseKeyPair(publicKey, privateKey, 'raw');
+  public static getKeyPairFromSecretPEMFile(privateKeyPath: string) {
+    const privateKey = Secp256K1.getSecretKeyFromPEMFile(privateKeyPath);
+    const publicKey = Secp256K1.getPublicKeyFromSecretKey(privateKey);
+    return Secp256K1.getKeyPairFromBytes(publicKey, privateKey, 'raw');
   }
 
   /**

--- a/packages/sdk/src/services/CasperServiceByJsonRPC.ts
+++ b/packages/sdk/src/services/CasperServiceByJsonRPC.ts
@@ -1,6 +1,6 @@
 import Client, { HTTPTransport, RequestManager } from 'rpc-client-js';
 import { DeployUtil, encodeBase16, PublicKey } from '..';
-import { deployToJson } from '../lib/DeployUtil';
+import { getDeployAsJSON } from '../lib/DeployUtil';
 
 interface RpcResult {
   api_version: string;
@@ -283,7 +283,7 @@ export class CasperServiceByJsonRPC {
   public async deploy(signedDeploy: DeployUtil.Deploy) {
     return await this.client.request({
       method: 'account_put_deploy',
-      params: deployToJson(signedDeploy)
+      params: getDeployAsJSON(signedDeploy)
     });
   }
 }

--- a/packages/sdk/test/lib/CasperClient.test.ts
+++ b/packages/sdk/test/lib/CasperClient.test.ts
@@ -18,7 +18,7 @@ describe('CasperClient', () => {
   });
 
   it('should generate new Ed25519 key pair, and compute public key from private key', () => {
-    const edKeyPair = casperClient.newKeyPair(SignatureAlgorithm.Ed25519);
+    const edKeyPair = casperClient.getKeyPair(SignatureAlgorithm.Ed25519);
     const publicKey = edKeyPair.publicKey.rawPublicKey;
     const privateKey = edKeyPair.privateKey;
     const convertFromPrivateKey = casperClient.privateToPublicKey(
@@ -29,23 +29,23 @@ describe('CasperClient', () => {
   });
 
   it('should generate PEM file for Ed25519 correctly', () => {
-    const edKeyPair = casperClient.newKeyPair(SignatureAlgorithm.Ed25519);
+    const edKeyPair = casperClient.getKeyPair(SignatureAlgorithm.Ed25519);
     const publicKeyInPem = edKeyPair.exportPublicKeyInPem();
     const privateKeyInPem = edKeyPair.exportPrivateKeyInPem();
 
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-'));
     fs.writeFileSync(tempDir + '/public.pem', publicKeyInPem);
     fs.writeFileSync(tempDir + '/private.pem', privateKeyInPem);
-    const publicKeyFromFIle = casperClient.loadPublicKeyFromFile(
+    const publicKeyFromFIle = casperClient.getPublicKeyFromPEMFile(
       tempDir + '/public.pem',
       SignatureAlgorithm.Ed25519
     );
-    const privateKeyFromFile = casperClient.loadPrivateKeyFromFile(
+    const privateKeyFromFile = casperClient.getSecretKeyFromPEMFile(
       tempDir + '/private.pem',
       SignatureAlgorithm.Ed25519
     );
 
-    const keyPairFromFile = Keys.Ed25519.parseKeyPair(
+    const keyPairFromFile = Keys.Ed25519.getKeyPairFromBytes(
       publicKeyFromFIle,
       privateKeyFromFile
     );
@@ -56,7 +56,7 @@ describe('CasperClient', () => {
     expect(keyPairFromFile.privateKey).to.deep.equal(edKeyPair.privateKey);
 
     // load the keypair from pem file of private key
-    const loadedKeyPair = casperClient.loadKeyPairFromPrivateFile(
+    const loadedKeyPair = casperClient.getKeyPairFromSecretPEMFile(
       tempDir + '/private.pem',
       SignatureAlgorithm.Ed25519
     );
@@ -67,7 +67,7 @@ describe('CasperClient', () => {
   });
 
   it('should generate new Secp256K1 key pair, and compute public key from private key', () => {
-    const edKeyPair = casperClient.newKeyPair(SignatureAlgorithm.Secp256K1);
+    const edKeyPair = casperClient.getKeyPair(SignatureAlgorithm.Secp256K1);
     const publicKey = edKeyPair.publicKey.rawPublicKey;
     const privateKey = edKeyPair.privateKey;
     const convertFromPrivateKey = casperClient.privateToPublicKey(
@@ -78,7 +78,7 @@ describe('CasperClient', () => {
   });
 
   it('should generate PEM file for Secp256K1 and restore the key pair from PEM file correctly', () => {
-    const edKeyPair: Secp256K1 = casperClient.newKeyPair(
+    const edKeyPair: Secp256K1 = casperClient.getKeyPair(
       SignatureAlgorithm.Secp256K1
     );
     const publicKeyInPem = edKeyPair.exportPublicKeyInPem();
@@ -87,16 +87,16 @@ describe('CasperClient', () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-'));
     fs.writeFileSync(tempDir + '/public.pem', publicKeyInPem);
     fs.writeFileSync(tempDir + '/private.pem', privateKeyInPem);
-    const publicKeyFromFIle = casperClient.loadPublicKeyFromFile(
+    const publicKeyFromFIle = casperClient.getPublicKeyFromPEMFile(
       tempDir + '/public.pem',
       SignatureAlgorithm.Secp256K1
     );
-    const privateKeyFromFile = casperClient.loadPrivateKeyFromFile(
+    const privateKeyFromFile = casperClient.getSecretKeyFromPEMFile(
       tempDir + '/private.pem',
       SignatureAlgorithm.Secp256K1
     );
 
-    const keyPairFromFile = Keys.Secp256K1.parseKeyPair(
+    const keyPairFromFile = Keys.Secp256K1.getKeyPairFromBytes(
       publicKeyFromFIle,
       privateKeyFromFile,
       'raw'
@@ -108,7 +108,7 @@ describe('CasperClient', () => {
     expect(keyPairFromFile.privateKey).to.deep.equal(edKeyPair.privateKey);
 
     // load the keypair from pem file of private key
-    const loadedKeyPair = casperClient.loadKeyPairFromPrivateFile(
+    const loadedKeyPair = casperClient.getKeyPairFromSecretPEMFile(
       tempDir + '/private.pem',
       SignatureAlgorithm.Secp256K1
     );
@@ -126,7 +126,7 @@ describe('CasperClient', () => {
         '01a72eb5ba13e243d40e56b0547536e3ad1584eee5a386c7be5d5a1f94c09a6592'
       )
     );
-    const keyPair = Ed25519.parseKeyFiles(
+    const keyPair = Ed25519.getKeyPairFromFiles(
       '../server/test.public.key',
       '../server/test.private.key'
     );
@@ -143,7 +143,7 @@ describe('CasperClient', () => {
   it('should create a HK wallet and derive child account correctly', function () {
     const seed =
       'fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542';
-    const hdKey = casperClient.newHdWallet(decodeBase16(seed));
+    const hdKey = casperClient.getWalletFromSeed(decodeBase16(seed));
     const secpKey1 = hdKey.deriveIndex(1);
     const msg = Buffer.from('hello world');
     const signature = secpKey1.sign(msg);

--- a/packages/sdk/test/lib/CasperClient.test.ts
+++ b/packages/sdk/test/lib/CasperClient.test.ts
@@ -17,45 +17,45 @@ describe('CasperClient', () => {
     );
   });
 
-  it('should generate new Ed25519 key pair, and compute public key from private key', () => {
+  it('should generate new Ed25519 key pair, and compute public key from secret key', () => {
     const edKeyPair = casperClient.getKeyPair(SignatureAlgorithm.Ed25519);
     const publicKey = edKeyPair.publicKey.rawPublicKey;
-    const privateKey = edKeyPair.privateKey;
-    const convertFromPrivateKey = casperClient.privateToPublicKey(
-      privateKey,
+    const secretKey = edKeyPair.secretKey;
+    const convertFromSecretKey = casperClient.getPublicKeyFromSecretKey(
+      secretKey,
       SignatureAlgorithm.Ed25519
     );
-    expect(convertFromPrivateKey).to.deep.equal(publicKey);
+    expect(convertFromSecretKey).to.deep.equal(publicKey);
   });
 
   it('should generate PEM file for Ed25519 correctly', () => {
     const edKeyPair = casperClient.getKeyPair(SignatureAlgorithm.Ed25519);
     const publicKeyInPem = edKeyPair.exportPublicKeyInPem();
-    const privateKeyInPem = edKeyPair.exportPrivateKeyInPem();
+    const secretKeyInPem = edKeyPair.exportSecretKeyInPem();
 
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-'));
     fs.writeFileSync(tempDir + '/public.pem', publicKeyInPem);
-    fs.writeFileSync(tempDir + '/private.pem', privateKeyInPem);
+    fs.writeFileSync(tempDir + '/private.pem', secretKeyInPem);
     const publicKeyFromFIle = casperClient.getPublicKeyFromPEMFile(
       tempDir + '/public.pem',
       SignatureAlgorithm.Ed25519
     );
-    const privateKeyFromFile = casperClient.getSecretKeyFromPEMFile(
+    const secretKeyFromFile = casperClient.getSecretKeyFromPEMFile(
       tempDir + '/private.pem',
       SignatureAlgorithm.Ed25519
     );
 
     const keyPairFromFile = Keys.Ed25519.getKeyPairFromBytes(
       publicKeyFromFIle,
-      privateKeyFromFile
+      secretKeyFromFile
     );
 
     expect(keyPairFromFile.publicKey.rawPublicKey).to.deep.equal(
       edKeyPair.publicKey.rawPublicKey
     );
-    expect(keyPairFromFile.privateKey).to.deep.equal(edKeyPair.privateKey);
+    expect(keyPairFromFile.secretKey).to.deep.equal(edKeyPair.secretKey);
 
-    // load the keypair from pem file of private key
+    // load the keypair from pem file of secret key
     const loadedKeyPair = casperClient.getKeyPairFromSecretPEMFile(
       tempDir + '/private.pem',
       SignatureAlgorithm.Ed25519
@@ -63,18 +63,18 @@ describe('CasperClient', () => {
     expect(loadedKeyPair.publicKey.rawPublicKey).to.deep.equal(
       edKeyPair.publicKey.rawPublicKey
     );
-    expect(loadedKeyPair.privateKey).to.deep.equal(edKeyPair.privateKey);
+    expect(loadedKeyPair.secretKey).to.deep.equal(edKeyPair.secretKey);
   });
 
-  it('should generate new Secp256K1 key pair, and compute public key from private key', () => {
+  it('should generate new Secp256K1 key pair, and compute public key from secret key', () => {
     const edKeyPair = casperClient.getKeyPair(SignatureAlgorithm.Secp256K1);
     const publicKey = edKeyPair.publicKey.rawPublicKey;
-    const privateKey = edKeyPair.privateKey;
-    const convertFromPrivateKey = casperClient.privateToPublicKey(
-      privateKey,
+    const secretKey = edKeyPair.secretKey;
+    const convertFromSecretKey = casperClient.getPublicKeyFromSecretKey(
+      secretKey,
       SignatureAlgorithm.Secp256K1
     );
-    expect(convertFromPrivateKey).to.deep.equal(publicKey);
+    expect(convertFromSecretKey).to.deep.equal(publicKey);
   });
 
   it('should generate PEM file for Secp256K1 and restore the key pair from PEM file correctly', () => {
@@ -82,32 +82,32 @@ describe('CasperClient', () => {
       SignatureAlgorithm.Secp256K1
     );
     const publicKeyInPem = edKeyPair.exportPublicKeyInPem();
-    const privateKeyInPem = edKeyPair.exportPrivateKeyInPem();
+    const secretKeyInPem = edKeyPair.exportSecretKeyInPem();
 
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-'));
     fs.writeFileSync(tempDir + '/public.pem', publicKeyInPem);
-    fs.writeFileSync(tempDir + '/private.pem', privateKeyInPem);
+    fs.writeFileSync(tempDir + '/private.pem', secretKeyInPem);
     const publicKeyFromFIle = casperClient.getPublicKeyFromPEMFile(
       tempDir + '/public.pem',
       SignatureAlgorithm.Secp256K1
     );
-    const privateKeyFromFile = casperClient.getSecretKeyFromPEMFile(
+    const secretKeyFromFile = casperClient.getSecretKeyFromPEMFile(
       tempDir + '/private.pem',
       SignatureAlgorithm.Secp256K1
     );
 
     const keyPairFromFile = Keys.Secp256K1.getKeyPairFromBytes(
       publicKeyFromFIle,
-      privateKeyFromFile,
+      secretKeyFromFile,
       'raw'
     );
 
     expect(keyPairFromFile.publicKey.rawPublicKey).to.deep.equal(
       edKeyPair.publicKey.rawPublicKey
     );
-    expect(keyPairFromFile.privateKey).to.deep.equal(edKeyPair.privateKey);
+    expect(keyPairFromFile.secretKey).to.deep.equal(edKeyPair.secretKey);
 
-    // load the keypair from pem file of private key
+    // load the keypair from pem file of secret key
     const loadedKeyPair = casperClient.getKeyPairFromSecretPEMFile(
       tempDir + '/private.pem',
       SignatureAlgorithm.Secp256K1
@@ -115,7 +115,7 @@ describe('CasperClient', () => {
     expect(loadedKeyPair.publicKey.rawPublicKey).to.deep.equal(
       edKeyPair.publicKey.rawPublicKey
     );
-    expect(loadedKeyPair.privateKey).to.deep.equal(edKeyPair.privateKey);
+    expect(loadedKeyPair.secretKey).to.deep.equal(edKeyPair.secretKey);
   });
 
   // todo move it to example once we publish transfer feature

--- a/packages/sdk/test/lib/Contracts.test.ts
+++ b/packages/sdk/test/lib/Contracts.test.ts
@@ -33,7 +33,7 @@ describe('sign', () => {
     const privateKey = decodeBase64(privateKeyBase64);
     const keyPair = Ed25519.getKeyPairFromBytes(publicKey, privateKey);
 
-    const signature = nacl.sign_detached(input, keyPair.privateKey);
+    const signature = nacl.sign_detached(input, keyPair.secretKey);
 
     const signatureHex = Buffer.from(signature).toString('hex');
     const expectedHex =

--- a/packages/sdk/test/lib/Contracts.test.ts
+++ b/packages/sdk/test/lib/Contracts.test.ts
@@ -31,7 +31,7 @@ describe('sign', () => {
       'MC4CAQAwBQYDK2VwBCIEIEIcqHCVzuejJfD9wCoGVOLc3YFNUa9dcsy+mv5j2sar';
     const publicKey = decodeBase64(publicKeyBase64);
     const privateKey = decodeBase64(privateKeyBase64);
-    const keyPair = Ed25519.parseKeyPair(publicKey, privateKey);
+    const keyPair = Ed25519.getKeyPairFromBytes(publicKey, privateKey);
 
     const signature = nacl.sign_detached(input, keyPair.privateKey);
 

--- a/packages/sdk/test/lib/Keys.test.ts
+++ b/packages/sdk/test/lib/Keys.test.ts
@@ -23,9 +23,9 @@ describe('Ed25519', () => {
     ]);
     const hash = byteHash(bytes);
 
-    expect(Ed25519.accountHash(signKeyPair.publicKey.rawPublicKey)).deep.equal(
-      hash
-    );
+    expect(
+      Ed25519.getAccountHashFromPublicKey(signKeyPair.publicKey.rawPublicKey)
+    ).deep.equal(hash);
   });
 
   it('should generate PEM file for Ed25519 correctly', () => {
@@ -36,7 +36,7 @@ describe('Ed25519', () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-'));
     fs.writeFileSync(tempDir + '/public.pem', publicKeyInPem);
     fs.writeFileSync(tempDir + '/private.pem', privateKeyInPem);
-    const signKeyPair2 = Ed25519.parseKeyFiles(
+    const signKeyPair2 = Ed25519.getKeyPairFromFiles(
       tempDir + '/public.pem',
       tempDir + '/private.pem'
     );
@@ -120,7 +120,7 @@ describe('Secp256K1', () => {
     const hash = byteHash(bytes);
 
     expect(
-      Secp256K1.accountHash(signKeyPair.publicKey.rawPublicKey)
+      Secp256K1.getAccountHash(signKeyPair.publicKey.rawPublicKey)
     ).deep.equal(hash);
   });
 
@@ -136,14 +136,14 @@ describe('Secp256K1', () => {
     fs.writeFileSync(tempDir + '/private.pem', privateKeyInPem);
 
     // expect importing keys from pem files works well
-    expect(Secp256K1.parsePublicKeyFile(tempDir + '/public.pem')).to.deep.eq(
-      signKeyPair.publicKey.rawPublicKey
-    );
-    expect(Secp256K1.parsePrivateKeyFile(tempDir + '/private.pem')).to.deep.eq(
-      signKeyPair.privateKey
-    );
+    expect(
+      Secp256K1.getPublicKeyFromPEMFile(tempDir + '/public.pem')
+    ).to.deep.eq(signKeyPair.publicKey.rawPublicKey);
+    expect(
+      Secp256K1.getSecretKeyFromPEMFile(tempDir + '/private.pem')
+    ).to.deep.eq(signKeyPair.privateKey);
 
-    const signKeyPair2 = Secp256K1.parseKeyFiles(
+    const signKeyPair2 = Secp256K1.getKeyPairFromFiles(
       tempDir + '/public.pem',
       tempDir + '/private.pem'
     );

--- a/packages/sdk/test/lib/Keys.test.ts
+++ b/packages/sdk/test/lib/Keys.test.ts
@@ -31,11 +31,11 @@ describe('Ed25519', () => {
   it('should generate PEM file for Ed25519 correctly', () => {
     const naclKeyPair = Ed25519.new();
     const publicKeyInPem = naclKeyPair.exportPublicKeyInPem();
-    const privateKeyInPem = naclKeyPair.exportPrivateKeyInPem();
+    const secretKeyInPem = naclKeyPair.exportSecretKeyInPem();
 
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-'));
     fs.writeFileSync(tempDir + '/public.pem', publicKeyInPem);
-    fs.writeFileSync(tempDir + '/private.pem', privateKeyInPem);
+    fs.writeFileSync(tempDir + '/private.pem', secretKeyInPem);
     const signKeyPair2 = Ed25519.getKeyPairFromFiles(
       tempDir + '/public.pem',
       tempDir + '/private.pem'
@@ -45,13 +45,13 @@ describe('Ed25519', () => {
     expect(encodeBase64(naclKeyPair.publicKey.rawPublicKey)).to.equal(
       encodeBase64(signKeyPair2.publicKey.rawPublicKey)
     );
-    expect(encodeBase64(naclKeyPair.privateKey)).to.equal(
-      encodeBase64(signKeyPair2.privateKey)
+    expect(encodeBase64(naclKeyPair.secretKey)).to.equal(
+      encodeBase64(signKeyPair2.secretKey)
     );
 
     // import pem file to nodejs std library
     const pubKeyImported = Crypto.createPublicKey(publicKeyInPem);
-    const priKeyImported = Crypto.createPrivateKey(privateKeyInPem);
+    const priKeyImported = Crypto.createPrivateKey(secretKeyInPem);
     expect(pubKeyImported.asymmetricKeyType).to.equal('ed25519');
 
     // expect nodejs std lib export the same pem.
@@ -59,19 +59,19 @@ describe('Ed25519', () => {
       type: 'spki',
       format: 'pem'
     });
-    const privateKeyInPemFromNode = priKeyImported.export({
+    const secretKeyInPemFromNode = priKeyImported.export({
       type: 'pkcs8',
       format: 'pem'
     });
     expect(publicKeyInPemFromNode).to.equal(publicKeyInPem);
-    expect(privateKeyInPemFromNode).to.equal(privateKeyInPem);
+    expect(secretKeyInPemFromNode).to.equal(secretKeyInPem);
 
     // expect both of they generate the same signature
     const message = Buffer.from('hello world');
     const signatureByNode = Crypto.sign(null, message, priKeyImported);
     const signatureByNacl = nacl.sign_detached(
       Buffer.from(message),
-      naclKeyPair.privateKey
+      naclKeyPair.secretKey
     );
     expect(encodeBase64(signatureByNode)).to.eq(encodeBase64(signatureByNacl));
 
@@ -129,11 +129,11 @@ describe('Secp256K1', () => {
 
     // export key in pem to save
     const publicKeyInPem = signKeyPair.exportPublicKeyInPem();
-    const privateKeyInPem = signKeyPair.exportPrivateKeyInPem();
+    const secretKeyInPem = signKeyPair.exportSecretKeyInPem();
 
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-'));
     fs.writeFileSync(tempDir + '/public.pem', publicKeyInPem);
-    fs.writeFileSync(tempDir + '/private.pem', privateKeyInPem);
+    fs.writeFileSync(tempDir + '/private.pem', secretKeyInPem);
 
     // expect importing keys from pem files works well
     expect(
@@ -141,7 +141,7 @@ describe('Secp256K1', () => {
     ).to.deep.eq(signKeyPair.publicKey.rawPublicKey);
     expect(
       Secp256K1.getSecretKeyFromPEMFile(tempDir + '/private.pem')
-    ).to.deep.eq(signKeyPair.privateKey);
+    ).to.deep.eq(signKeyPair.secretKey);
 
     const signKeyPair2 = Secp256K1.getKeyPairFromFiles(
       tempDir + '/public.pem',
@@ -152,13 +152,13 @@ describe('Secp256K1', () => {
     expect(encodeBase64(signKeyPair.publicKey.rawPublicKey)).to.equal(
       encodeBase64(signKeyPair2.publicKey.rawPublicKey)
     );
-    expect(encodeBase64(signKeyPair.privateKey)).to.equal(
-      encodeBase64(signKeyPair2.privateKey)
+    expect(encodeBase64(signKeyPair.secretKey)).to.equal(
+      encodeBase64(signKeyPair2.secretKey)
     );
 
     // import pem file to nodejs std library
     const ecdh = Crypto.createECDH('secp256k1');
-    ecdh.setPrivateKey(signKeyPair.privateKey);
+    ecdh.setPrivateKey(signKeyPair.secretKey);
     expect(ecdh.getPublicKey('hex', 'compressed')).to.deep.equal(
       encodeBase16(signKeyPair.publicKey.rawPublicKey)
     );

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -2,10 +2,9 @@
   "compilerOptions": {
     "outDir": "./dist/",
     "alwaysStrict": true,
-    "declaration": false,
+    "declaration": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-	"noEmit": true,
     "sourceMap": true,
     "noImplicitAny": true,
     "strictNullChecks": true,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -40,7 +40,7 @@
     "@types/http-proxy-middleware": "^0.19.3",
     "auth0": "^2.28.0",
     "blakejs": "^1.1.0",
-    "casper-client-sdk": "latest",
+    "casper-client-sdk": "1.0.7",
     "command-line-args": "^5.1.1",
     "cron": "1.7.2",
     "dotenv": "^8.0.0",

--- a/packages/server/src/StoredFaucetService.ts
+++ b/packages/server/src/StoredFaucetService.ts
@@ -68,7 +68,7 @@ export class StoredFaucetService {
       }
       const globalStateHash = LFB.header!.state_root_hash!;
 
-      const accountHash = this.contractKeys.accountHash();
+      const accountHash = this.contractKeys.getAccountHash();
       const key = 'account-hash-' + encodeBase16(accountHash);
       const state = await this.casperService.getBlockState(
         globalStateHash,

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -98,7 +98,7 @@ if (enableAuth0Metrics) {
 // as if it were an environment variable
 const port = process.env.SERVER_PORT!;
 
-const contractKeys = Keys.Ed25519.parseKeyFiles(
+const contractKeys = Keys.Ed25519.getKeyPairFromFiles(
   process.env.FAUCET_ACCOUNT_PUBLIC_KEY_PATH!,
   process.env.FAUCET_ACCOUNT_PRIVATE_KEY_PATH!
 );

--- a/packages/server/src/transfer.ts
+++ b/packages/server/src/transfer.ts
@@ -28,14 +28,14 @@ for (const opt of optionDefinitions) {
   }
 }
 
-const contractKeys = Keys.Ed25519.parseKeyFiles(
+const contractKeys = Keys.Ed25519.getKeyPairFromFiles(
   options['from-public-key-path'],
   options['from-private-key-path']
 );
 
 const hex = (x: ByteArray) => Buffer.from(x).toString('hex');
 
-const accountPublicKey = Keys.Ed25519.parsePublicKeyFile(
+const accountPublicKey = Keys.Ed25519.getPublicKeyFromPEMFile(
   options['to-public-key-path']
 );
 const accountPublicKeyBase16 = hex(accountPublicKey);

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -28,7 +28,7 @@
     "downshift": "^6.0.2",
     "file-saver": "^2.0.2",
     "formstate": "^1.3.0",
-    "casper-client-sdk": "latest",
+    "casper-client-sdk": "1.0.7",
     "jquery": "^3.4.1",
     "jsbi": "^3.1.2",
     "kind-of": "^6.0.3",

--- a/packages/ui/src/components/Accounts.tsx
+++ b/packages/ui/src/components/Accounts.tsx
@@ -69,8 +69,8 @@ export default class Accounts extends RefreshableComponent<Props, {}> {
             <TextArea disabled={true} label={'Public Key'}>
               {newAccountForm.getKeys.exportPublicKeyInPem()}
             </TextArea>
-            <TextArea disabled={true} label={'Private Key'}>
-              {newAccountForm.getKeys.exportPrivateKeyInPem()}
+            <TextArea disabled={true} label={'Secret Key'}>
+              {newAccountForm.getKeys.exportSecretKeyInPem()}
             </TextArea>
           </Form>
         </Modal>

--- a/packages/ui/src/containers/AuthContainer.ts
+++ b/packages/ui/src/containers/AuthContainer.ts
@@ -15,7 +15,6 @@ import {
 } from 'casper-client-sdk';
 import ObservableValueMap from '../lib/ObservableValueMap';
 import { FieldState } from 'formstate';
-import { AsymmetricKey } from 'casper-client-sdk/dist/lib/Keys';
 
 // https://www.npmjs.com/package/tweetnacl-ts#signatures
 // https://tweetnacl.js.org/#/sign
@@ -175,7 +174,7 @@ export class AuthContainer {
     if (form instanceof NewAccountFormData && form.clean()) {
       // Save the private and public keys to disk.
       saveToFile(
-        form.getKeys.exportPrivateKeyInPem(),
+        form.getKeys.exportSecretKeyInPem(),
         `${form.name.$}_secret_key.pem`
       );
       saveToFile(
@@ -297,17 +296,17 @@ class AccountFormData extends CleanableFormData {
 }
 
 export class NewAccountFormData extends AccountFormData {
-  @observable privateKeyBase64: string = '';
-  private keys: AsymmetricKey;
+  @observable secretKeyBase64: string = '';
+  private keys: Keys.AsymmetricKey;
 
   constructor(accounts: UserAccount[]) {
     super(accounts);
-    // Generate key pair and assign to public and private keys.
+    // Generate key pair and assign to public and secret keys.
     this.keys = Keys.Ed25519.new();
     this.publicKeyBase64 = new FieldState<string>(
       encodeBase64(this.keys.publicKey.rawPublicKey)
     );
-    this.privateKeyBase64 = encodeBase64(this.keys.privateKey);
+    this.secretKeyBase64 = encodeBase64(this.keys.secretKey);
   }
 
   get getKeys() {

--- a/packages/ui/src/containers/AuthContainer.ts
+++ b/packages/ui/src/containers/AuthContainer.ts
@@ -23,7 +23,7 @@ import { AsymmetricKey } from 'casper-client-sdk/dist/lib/Keys';
 type AccountB64 = string;
 
 export const accountHashForEd25519 = (publicKeyBase64: string) => {
-  return Keys.Ed25519.accountHex(decodeBase64(publicKeyBase64));
+  return Keys.Ed25519.getAccountHex(decodeBase64(publicKeyBase64));
 };
 
 export const getPublicKeyHashBase64 = (account: UserAccount) => {


### PR DESCRIPTION
### Overview
Rename API methods:
```
balanceOfByAccountHash      -->  getBalanceByAccountHash
balanceOfByPublicKey        -->  getBalanceByPublicKey
deployToJson                -->  getDeployAsJSON
getAccountsDeploys          -->  getAccountDeploys
loadKeyPairFromPrivateFile  -->  getKeyPairFromSecretPEMFile
loadPrivateKeyFromFile      -->  getSecretKeyFromPEMFile
loadPublicKeyFromFile       -->  getPublicKeyFromPEMFile
newHdWallet                 -->  getWalletFromSeed
newKeyPair                  -->  getKeyPair
privateToPublicKey          -->  getPublicKeyFromSecretKey
```
And also rename private key secret key everywhere.

### Which JIRA ticket does this PR relate to?

_Add the link here. Create a ticket and link it here if one does not exist._

### Complete this checklist before you submit this PR

- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes

_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
