### PR TITLE
ECO-790: QueryState  method - Casper Client

### DIFF
--- a/packages/sdk/src/lib/CLValue.ts
+++ b/packages/sdk/src/lib/CLValue.ts
@@ -376,7 +376,7 @@ class U256 extends NumberCoder {
 }
 
 @staticImplements<BytesDeserializableStatic<U512>>()
-class U512 extends NumberCoder {
+export class U512 extends NumberCoder {
   constructor(n: BigNumberish) {
     super(512, false, n);
   }
@@ -1195,8 +1195,8 @@ class ByteArrayValue extends CLTypedAndToBytes {
     if (u32Res.remainder.length < size) {
       return Result.Err(FromBytesError.EarlyEndOfStream);
     }
-    const b = new ByteArrayValue(u32Res.remainder.subarray(0, length));
-    const rem = u32Res.remainder.subarray(length);
+    const b = new ByteArrayValue(u32Res.remainder.subarray(0, size));
+    const rem = u32Res.remainder.subarray(size);
     return Result.Ok(b, rem);
   }
 }

--- a/packages/sdk/src/lib/StoredValue.ts
+++ b/packages/sdk/src/lib/StoredValue.ts
@@ -1,5 +1,6 @@
 import { jsonArrayMember, jsonMember, jsonObject } from 'typedjson';
 import { CLValue } from './CLValue';
+import { decodeBase16 } from './Conversions';
 
 @jsonObject
 class NamedKey {
@@ -50,19 +51,26 @@ class AccountJson {
 @jsonObject
 class CLValueJson {
   @jsonMember({ name: 'cl_type', constructor: String })
-  public clTypeStr: string;
+  public typeStr: string;
 
-  @jsonMember({ name: 'serialized_bytes', constructor: String })
-  public serializedBytes: string;
-
-  public clValue?: CLValue;
+  @jsonMember({
+    name: 'serialized_bytes',
+    deserializer: (b: string) => {
+      const res = CLValue.fromBytes(decodeBase16(b));
+      if (res.hasError()) {
+        throw res.error;
+      }
+      return res.value;
+    }
+  })
+  public value: CLValue;
 
   @jsonMember({
     name: 'parsed_to_json',
-    constructor: String,
+    deserializer: v => v,
     preserveNull: true
   })
-  public parsedToJson: string | null;
+  public parsedToJson: string | number | null;
 }
 
 @jsonObject

--- a/packages/sdk/src/lib/StoredValue.ts
+++ b/packages/sdk/src/lib/StoredValue.ts
@@ -1,4 +1,5 @@
 import { jsonArrayMember, jsonMember, jsonObject } from 'typedjson';
+import { CLValue } from './CLValue';
 
 @jsonObject
 class NamedKey {
@@ -29,7 +30,7 @@ class ActionThresholds {
  * Structure representing a user's account, stored in global state.
  */
 @jsonObject
-class SAccount {
+class AccountJson {
   get accountHash(): string {
     return this._accountHash;
   }
@@ -47,7 +48,25 @@ class SAccount {
 }
 
 @jsonObject
-export class STransfer {
+class CLValueJson {
+  @jsonMember({ name: 'cl_type', constructor: String })
+  public clTypeStr: string;
+
+  @jsonMember({ name: 'serialized_bytes', constructor: String })
+  public serializedBytes: string;
+
+  public clValue?: CLValue;
+
+  @jsonMember({
+    name: 'parsed_to_json',
+    constructor: String,
+    preserveNull: true
+  })
+  public parsedToJson: string | null;
+}
+
+@jsonObject
+export class TransferJson {
   // Deploy that created the transfer
   @jsonMember({ name: 'deploy_hash', constructor: String })
   public deployHash: string;
@@ -78,7 +97,7 @@ export class STransfer {
 }
 
 @jsonObject
-export class SDeployInfo {
+export class DeployInfoJson {
   // The relevant Deploy.
   @jsonMember({ name: 'deploy_hash', constructor: String })
   public deployHash: string;
@@ -147,18 +166,19 @@ export class SeigniorageAllocation {
  * Auction metdata.  Intended to be recorded at each era.
  */
 @jsonObject
-export class EraInfo {
+export class EraInfoJson {
   @jsonArrayMember(SeigniorageAllocation, { name: 'seigniorage_allocations' })
   public seigniorageAllocations: SeigniorageAllocation[];
 }
 
 @jsonObject
 export class StoredValue {
-  // todo SCLValue;
-
+  // StoredValue
+  @jsonMember({ constructor: CLValueJson })
+  public CLValue?: CLValueJson;
   // An account
-  @jsonMember({ constructor: SAccount })
-  public Account?: SAccount;
+  @jsonMember({ constructor: AccountJson })
+  public Account?: AccountJson;
 
   // A contract's Wasm
   @jsonMember({ constructor: String })
@@ -173,13 +193,13 @@ export class StoredValue {
   public ContractPackage?: string;
 
   // A record of a transfer
-  @jsonMember({ constructor: STransfer })
-  public Transfer?: STransfer;
+  @jsonMember({ constructor: TransferJson })
+  public Transfer?: TransferJson;
 
   // A record of a deploy
-  @jsonMember({ constructor: SDeployInfo })
-  public DeployInfo?: SDeployInfo;
+  @jsonMember({ constructor: DeployInfoJson })
+  public DeployInfo?: DeployInfoJson;
 
-  @jsonMember({ constructor: EraInfo })
-  public EraInfo?: EraInfo;
+  @jsonMember({ constructor: EraInfoJson })
+  public EraInfo?: EraInfoJson;
 }

--- a/packages/sdk/src/services/CasperServiceByJsonRPC.ts
+++ b/packages/sdk/src/services/CasperServiceByJsonRPC.ts
@@ -1,6 +1,8 @@
 import Client, { HTTPTransport, RequestManager } from 'rpc-client-js';
-import { DeployUtil, encodeBase16, PublicKey } from '..';
+import { CLValue, decodeBase16, DeployUtil, encodeBase16, PublicKey } from '..';
 import { deployToJson } from '../lib/DeployUtil';
+import { TypedJSON } from 'typedjson';
+import { StoredValue } from '../lib/StoredValue';
 
 interface RpcResult {
   api_version: string;
@@ -270,7 +272,7 @@ export class CasperServiceByJsonRPC {
     key: string,
     path: string[]
   ) {
-    return await this.client.request({
+    const res = await this.client.request({
       method: 'state_get_item',
       params: {
         state_root_hash: stateRootHash,
@@ -278,6 +280,23 @@ export class CasperServiceByJsonRPC {
         path
       }
     });
+    if (res.error) {
+      return res;
+    } else {
+      const storedValueJson = res.result.stored_value;
+      const serializer = new TypedJSON(StoredValue);
+      const storedValue = serializer.parse(storedValueJson);
+
+      if (storedValue!.CLValue) {
+        const clValue = CLValue.fromBytes(
+          decodeBase16(storedValue!.CLValue.serializedBytes)
+        );
+        storedValue!.CLValue.clValue = clValue.value;
+        return storedValue;
+      } else {
+        return storedValue;
+      }
+    }
   }
 
   public async deploy(signedDeploy: DeployUtil.Deploy) {

--- a/packages/sdk/src/services/CasperServiceByJsonRPC.ts
+++ b/packages/sdk/src/services/CasperServiceByJsonRPC.ts
@@ -1,5 +1,5 @@
 import Client, { HTTPTransport, RequestManager } from 'rpc-client-js';
-import { CLValue, decodeBase16, DeployUtil, encodeBase16, PublicKey } from '..';
+import { DeployUtil, encodeBase16, PublicKey } from '..';
 import { deployToJson } from '../lib/DeployUtil';
 import { TypedJSON } from 'typedjson';
 import { StoredValue } from '../lib/StoredValue';
@@ -216,8 +216,8 @@ export class CasperServiceByJsonRPC {
       stateRootHash,
       'account-hash-' + accountHash,
       []
-    ).then(res => res.stored_value.Account);
-    return account.main_purse;
+    ).then(res => res.Account!);
+    return account.mainPurse;
   }
 
   /**
@@ -271,7 +271,7 @@ export class CasperServiceByJsonRPC {
     stateRootHash: string,
     key: string,
     path: string[]
-  ) {
+  ): Promise<StoredValue> {
     const res = await this.client.request({
       method: 'state_get_item',
       params: {
@@ -283,19 +283,10 @@ export class CasperServiceByJsonRPC {
     if (res.error) {
       return res;
     } else {
-      const storedValueJson = res.result.stored_value;
+      const storedValueJson = res.stored_value;
       const serializer = new TypedJSON(StoredValue);
-      const storedValue = serializer.parse(storedValueJson);
-
-      if (storedValue!.CLValue) {
-        const clValue = CLValue.fromBytes(
-          decodeBase16(storedValue!.CLValue.serializedBytes)
-        );
-        storedValue!.CLValue.clValue = clValue.value;
-        return storedValue;
-      } else {
-        return storedValue;
-      }
+      const storedValue = serializer.parse(storedValueJson)!;
+      return storedValue;
     }
   }
 


### PR DESCRIPTION
### Overview
Supporting querying global state.

And we need `casper-node` to export the whole serialized clValue. The related PR is: https://github.com/CasperLabs/casper-node/pull/701 

### Which JIRA ticket does this PR relate to?

_Add the link here. Create a ticket and link it here if one does not exist._

### Complete this checklist before you submit this PR

- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes

_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
