### PR TITLE
OP-1795: Use NPM Drone plugin for publishing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -120,25 +120,26 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: npm publish
+name: npm-publish-tag
 
 steps:
-- name: npm publish
-  image: "casperlabs/clarity-build:latest"
-  environment:
-    NPM_TOKEN:
-      from_secret: npm_token  
-  commands:
-    - "git fetch"
-    - "git checkout $DRONE_TAG"
-    - "cd packages/sdk"
-    - "npm version"
-    - "npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN"
-    - "npm whoami"
-    - "npm publish --verbose"
+- name: npm-publish
+  image: plugins/npm
+  failure: "ignore"
+  settings:
+    username:
+      from_secret: npm_user
+    token:
+      from_secret: npm_token
+    email:
+      from_secret: npm_email
+    folder:
+    - "packages/sdk"
+    fail_on_version_conflict:
+    - true
+    access:
+    - "public"
 
 trigger:
-  event:
-  - tag
-
-
+  ref:
+  - refs/tags/sdk*


### PR DESCRIPTION
### Overview
Refactors npm publish to use drone npm plugin and switches trigger to act only on 'sdk' prefixed tags.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-1795

### Complete this checklist before you submit this PR

- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes

_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
