### PR TITLE
[OP-1795] SDK pre-publish 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -120,10 +120,17 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: npm-publish-tag
+name: sdk-publish-tag
 
 steps:
-- name: npm-publish
+- name: sdk-pre-publish
+  image: "casperlabs/clarity-build:latest"
+  commands:
+  - "yarn install"
+  - "cd packages/sdk"
+  - "npm run-script prepublishOnly"
+
+- name: sdk-publish
   image: plugins/npm
   failure: "ignore"
   settings:


### PR DESCRIPTION
### Overview
This PR introduces a pre-publish step for drone in the sdk tag pipeline. This is needed as a workaround for `dist` directory being missing on tagged publishes to NPM.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-1795

### Complete this checklist before you submit this PR

- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes

_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
