### PR TITLE
NO TICK - Trying to fix client-sdk build inside clarity Docker image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,10 @@ test:
 
 # install all package
 .make/bootstrap:
-	npm install tslint
 	npm install lerna
 	yarn bootstrap
+	cd packages/sdk
+	npm install tslint
 
 .make/npm/build-explorer: .make/bootstrap
 	# CI=false so on Drone it won't fail on warnings (currently about href).

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,9 @@ test:
 
 # install all package
 .make/bootstrap:
+	npm install tslint
+	npm install lerna
 	yarn bootstrap
-
 
 .make/npm/build-explorer: .make/bootstrap
 	# CI=false so on Drone it won't fail on warnings (currently about href).


### PR DESCRIPTION
Adding more possible missing components to bootstrap that may be why  client-sdk isn't building in clarity.

