### PR TITLE
Bumps version and adds MAKE domain

### DIFF
--- a/packages/signer/package.json
+++ b/packages/signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.13.0",

--- a/packages/signer/public/manifest.json
+++ b/packages/signer/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "0.3.3",
+  "version": "0.3.4",
   "name": "CasperLabs Signer",
   "author": "https://casperlabs.io",
   "description": "CasperLabs Signer tool for signing transactions on the blockchain.",
@@ -19,7 +19,11 @@
   },
   "content_scripts": [
     {
-      "matches": ["*://*.casperlabs.io/*", "*://localhost/*"],
+      "matches": [
+        "*://*.casperlabs.io/*", 
+        "*://localhost/*",
+        "*://*.make.services/*"
+      ],
       "js": ["./scripts/content/content.js"],
       "run_at": "document_start",
       "all_frames": true


### PR DESCRIPTION
No Ticket

Adds MAKE services domain to allow Signer functionality on their instance of Clarity.
Bumps version to 0.3.4
SDK already set to 'latest' version.