### PR TITLE
Fixed validators page crash

### DIFF
--- a/packages/ui/src/components/Validators.tsx
+++ b/packages/ui/src/components/Validators.tsx
@@ -99,7 +99,7 @@ export default class Validators extends RefreshableComponent<Props, {}> {
                 <td>{index! + 1}</td>
                 <td>{bidInfo.delegation_rate}</td>
                 <td>
-                  <CSPR motes={bidInfo.stakeStr} />
+                  <CSPR motes={bidInfo.stakeNum} />
                 </td>
               </tr>
             );


### PR DESCRIPTION
### Overview

Atm the "Validators" page crashes with:

```
asyncToGenerator.js:6 Uncaught (in promise) TypeError: e.motes.div is not a function
    at He (Utils.tsx:237)
    at Qo (react-dom.production.min.js:153)
    at gu (react-dom.production.min.js:261)
    at cs (react-dom.production.min.js:246)
    at us (react-dom.production.min.js:246)
    at $u (react-dom.production.min.js:239)
    at react-dom.production.min.js:123
    at t.unstable_runWithPriority (scheduler.production.min.js:19)
    at Hi (react-dom.production.min.js:122)
    at Wi (react-dom.production.min.js:123)
```

### Which JIRA ticket does this PR relate to?

No ticket. Can't create one

### Complete this checklist before you submit this PR

- [x] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards). (there are no Javascript standards)
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR. (can't assign, it doesn't let me)
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR. (can't do that, I'm not a part of the organzation)
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes

