### PR TITLE
SDK v1.0.20 - Buffer to Uint8Array fix

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to casper-client-sdk.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.19]
+## 1.0.20
+
+### Fixed
+
+- Deserialize `Deploy.hash` to `Uint8Array` instead of `Buffer`.
+
+## 1.0.19
 
 ### Added
 
@@ -14,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - BytesArrayValue's fromBytes.
 
-## [1.0.18]
+## 1.0.18
 
 ### Added
 
@@ -24,7 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Deploy's body hash derivation.
 
-## [1.0.17]
+## 1.0.17
 
 ### Added
 
@@ -35,7 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Default `gasPrice` changed from `10` to `1`.
 - Casper balances checks return `BigNumber` now.
 
-## [1.0.15]
+## 1.0.15
 
 ### Added
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-client-sdk",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "main": "dist/index.js",

--- a/packages/sdk/src/lib/Conversions.ts
+++ b/packages/sdk/src/lib/Conversions.ts
@@ -26,5 +26,5 @@ export function encodeBase16(bytes: Uint8Array): string {
  * @param base16String base16 encoded string
  */
 export function decodeBase16(base16String: string): Uint8Array {
-  return Buffer.from(base16String, 'hex');
+  return new Uint8Array(Buffer.from(base16String, 'hex'));
 }

--- a/packages/sdk/src/lib/DeployUtil.ts
+++ b/packages/sdk/src/lib/DeployUtil.ts
@@ -57,7 +57,9 @@ const byteArrayJsonSerializer: (bytes: Uint8Array) => string = (
   return encodeBase16(bytes);
 };
 
-const byteArrayJsonDeserializer: (str: string) => ByteArray = (str: string) => {
+const byteArrayJsonDeserializer: (str: string) => Uint8Array = (
+  str: string
+) => {
   return decodeBase16(str);
 };
 

--- a/packages/sdk/test/lib/DeployUtil.test.ts
+++ b/packages/sdk/test/lib/DeployUtil.test.ts
@@ -3,7 +3,7 @@ import { Keys, DeployUtil, CLValue } from '../../src/lib';
 import { TypedJSON } from 'typedjson';
 
 describe('DeployUtil', () => {
-  it('should stringify/parse DeployHeader correctly', function() {
+  it('should stringify/parse DeployHeader correctly', function () {
     const ed25519Key = Keys.Ed25519.new();
     const deployHeader = new DeployUtil.DeployHeader(
       ed25519Key.publicKey,
@@ -20,7 +20,7 @@ describe('DeployUtil', () => {
     expect(deployHeader1).to.deep.equal(deployHeader);
   });
 
-  it('should allow to extract data from Transfer', function() {
+  it('should allow to extract data from Transfer', function () {
     const senderKey = Keys.Ed25519.new();
     const recipientKey = Keys.Ed25519.new();
     const networkName = 'test-network';
@@ -53,17 +53,11 @@ describe('DeployUtil', () => {
     assert.isTrue(deploy.isStandardPayment());
     assert.deepEqual(deploy.header.account, senderKey.publicKey);
     assert.deepEqual(
-      deploy.payment
-        .getArgByName('amount')!
-        .asBigNumber()
-        .toNumber(),
+      deploy.payment.getArgByName('amount')!.asBigNumber().toNumber(),
       paymentAmount
     );
     assert.deepEqual(
-      deploy.session
-        .getArgByName('amount')!
-        .asBigNumber()
-        .toNumber(),
+      deploy.session.getArgByName('amount')!.asBigNumber().toNumber(),
       transferAmount
     );
     assert.deepEqual(
@@ -83,7 +77,7 @@ describe('DeployUtil', () => {
     assert.deepEqual(deploy.approvals[1].signer, recipientKey.accountHex());
   });
 
-  it('should allow to add arg to Deploy', function() {
+  it('should allow to add arg to Deploy', function () {
     const senderKey = Keys.Ed25519.new();
     const recipientKey = Keys.Ed25519.new();
     const networkName = 'test-network';
@@ -117,27 +111,18 @@ describe('DeployUtil', () => {
     deploy = DeployUtil.deployFromJson(json)!;
 
     assert.deepEqual(
-      deploy.session
-        .getArgByName('custom_id')!
-        .asBigNumber()
-        .toNumber(),
+      deploy.session.getArgByName('custom_id')!.asBigNumber().toNumber(),
       customId
     );
     assert.isTrue(deploy.isTransfer());
     assert.isTrue(deploy.isStandardPayment());
     assert.deepEqual(deploy.header.account, senderKey.publicKey);
     assert.deepEqual(
-      deploy.payment
-        .getArgByName('amount')!
-        .asBigNumber()
-        .toNumber(),
+      deploy.payment.getArgByName('amount')!.asBigNumber().toNumber(),
       paymentAmount
     );
     assert.deepEqual(
-      deploy.session
-        .getArgByName('amount')!
-        .asBigNumber()
-        .toNumber(),
+      deploy.session.getArgByName('amount')!.asBigNumber().toNumber(),
       transferAmount
     );
     assert.deepEqual(
@@ -158,7 +143,7 @@ describe('DeployUtil', () => {
     assert.notEqual(oldDeploy.header.bodyHash, deploy.header.bodyHash);
   });
 
-  it('should not allow to add arg to a signed Deploy', function() {
+  it('should not allow to add arg to a signed Deploy', function () {
     const senderKey = Keys.Ed25519.new();
     const recipientKey = Keys.Ed25519.new();
     const networkName = 'test-network';
@@ -187,7 +172,7 @@ describe('DeployUtil', () => {
     }).to.throw('Can not add argument to already signed deploy.');
   });
 
-  it('should allow to extract additional args from Transfer.', function() {
+  it('should allow to extract additional args from Transfer.', function () {
     const from = Keys.Ed25519.new();
     const to = Keys.Ed25519.new();
     const networkName = 'test-network';

--- a/packages/sdk/test/lib/RuntimeArgs.test.ts
+++ b/packages/sdk/test/lib/RuntimeArgs.test.ts
@@ -61,14 +61,8 @@ describe(`RuntimeArgs`, () => {
     let str = serializer.stringify(value);
     let parsed = serializer.parse(str)!;
     assert.deepEqual(
-      value
-        .asOption()
-        .getSome()
-        .asBigNumber(),
-      parsed
-        .asOption()
-        .getSome()
-        .asBigNumber()
+      value.asOption().getSome().asBigNumber(),
+      parsed.asOption().getSome().asBigNumber()
     );
   });
 
@@ -80,12 +74,7 @@ describe(`RuntimeArgs`, () => {
     let serializer = new TypedJSON(RuntimeArgs);
     let str = serializer.stringify(runtimeArgs);
     let value = serializer.parse(str)!;
-    assert.isTrue(
-      value.args
-        .get('a')!
-        .asOption()
-        .isNone()
-    );
+    assert.isTrue(value.args.get('a')!.asOption().isNone());
   });
 
   it('should allow to extract lists of account hashes.', () => {


### PR DESCRIPTION
## SDK 1.0.20

### Fixed

- Deserialize `Deploy.hash` to `Uint8Array` instead of `Buffer`.

### Which JIRA ticket does this PR relate to?

https://casperlabs.atlassian.net/browse/DEV-27