### PR TITLE
SDK v1.0.21: Public Keys + getDeployHashWithRPC

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to casper-client-sdk.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.21
+
+### Added
+
+- `CasperClient.getDeployByHashFromRPC` allows for getting `Deploy` instance from the Node's RPC.
+
+### Fixed
+
+- Secp keys generator returns `Uint8Array` instead of `Buffer`.
+
+### Changed
+
+- `CLValue.publicKey` accepts `PublicKey` object.
+
 ## 1.0.20
 
 ### Fixed

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-client-sdk",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "main": "dist/index.js",

--- a/packages/sdk/src/lib/CLValue.ts
+++ b/packages/sdk/src/lib/CLValue.ts
@@ -650,6 +650,14 @@ export class PublicKey extends CLTypedAndToBytes {
     return accountHash;
   }
 
+  public isEd25519() {
+    return this.tag === ED25519_TAG
+  }
+
+  public isSecp256K1() {
+    return this.tag === SECP256K1_TAG
+  }
+
   public toAccountHash(): Uint8Array {
     const algorithmIdentifier = this.signatureAlgorithm();
     const separator = Buffer.from([0]);
@@ -1629,8 +1637,8 @@ export class CLValue implements ToBytes {
     return CLValue.fromT(new MapValue(mapEntries));
   }
 
-  public static publicKey(publicKey: Uint8Array) {
-    return CLValue.fromT(PublicKey.fromEd25519(publicKey));
+  public static publicKey(publicKey: PublicKey) {
+    return CLValue.fromT(publicKey);
   }
 
   public static byteArray(bytes: Uint8Array) {

--- a/packages/sdk/src/lib/CasperClient.ts
+++ b/packages/sdk/src/lib/CasperClient.ts
@@ -3,6 +3,7 @@ import {
   CasperServiceByJsonRPC,
   DeployResult,
   EventService,
+  GetDeployResult,
   TransferResult
 } from '../services';
 import { DeployUtil, Keys, PublicKey } from './index';
@@ -252,6 +253,17 @@ export class CasperClient {
    */
   public async getDeployByHash(deployHash: string): Promise<DeployResult> {
     return await this.eventStoreClient.getDeployByHash(deployHash);
+  }
+
+  /**
+   * Get deploy by hash from RPC.
+   * @param deployHash
+   * @returns Tuple of Deploy and raw RPC response.
+   */
+  public async getDeployByHashFromRPC(deployHash: string): Promise<[Deploy, GetDeployResult]> {
+    return await this.nodeClient.getDeployInfo(deployHash).then((result: GetDeployResult) => {
+      return [DeployUtil.deployFromJson(result)!, result];
+    });
   }
 
   /**

--- a/packages/sdk/src/lib/CasperHDKey.ts
+++ b/packages/sdk/src/lib/CasperHDKey.ts
@@ -51,7 +51,10 @@ export class CasperHDKey {
    */
   public derive(path: string): Secp256K1 {
     const secpKeyPair = this.hdKey.derive(path);
-    return new Secp256K1(secpKeyPair.publicKey!, secpKeyPair.privateKey!);
+    return new Secp256K1(
+      new Uint8Array(secpKeyPair.publicKey!), 
+      new Uint8Array(secpKeyPair.privateKey!)
+    );
   }
 
   /**

--- a/packages/sdk/test/lib/DeployUtil.test.ts
+++ b/packages/sdk/test/lib/DeployUtil.test.ts
@@ -173,7 +173,8 @@ describe('DeployUtil', () => {
   });
 
   it('should allow to extract additional args from Transfer.', function () {
-    const from = Keys.Ed25519.new();
+    // const from = Keys.Ed25519.new();
+    const from = Keys.Secp256K1.new();
     const to = Keys.Ed25519.new();
     const networkName = 'test-network';
     const paymentAmount = 10000000000000;
@@ -189,18 +190,16 @@ describe('DeployUtil', () => {
     );
     let payment = DeployUtil.standardPayment(paymentAmount);
     let deploy = DeployUtil.makeDeploy(deployParams, session, payment);
-    let fromRawPK = from.publicKey.rawPublicKey;
 
     let transferDeploy = DeployUtil.addArgToDeploy(
       deploy,
       'fromPublicKey',
-      CLValue.publicKey(fromRawPK)
+      CLValue.publicKey(from.publicKey)
     );
 
     assert.deepEqual(
-      transferDeploy.session.getArgByName('fromPublicKey')?.asPublicKey()
-        .rawPublicKey,
-      fromRawPK
+      transferDeploy.session.getArgByName('fromPublicKey')?.asPublicKey(),
+      from.publicKey
     );
 
     let newTransferDeploy = DeployUtil.deployFromJson(
@@ -208,9 +207,8 @@ describe('DeployUtil', () => {
     );
 
     assert.deepEqual(
-      newTransferDeploy?.session.getArgByName('fromPublicKey')?.asPublicKey()
-        .rawPublicKey,
-      fromRawPK
+      newTransferDeploy?.session.getArgByName('fromPublicKey')?.asPublicKey(),
+      from.publicKey
     );
   });
 });

--- a/packages/ui/src/lib/DeployArgumentParser.ts
+++ b/packages/ui/src/lib/DeployArgumentParser.ts
@@ -11,7 +11,8 @@ import {
   KeyValue,
   NamedArg,
   MapEntry,
-  CLTypedAndToBytesHelper
+  CLTypedAndToBytesHelper,
+  PublicKey
 } from 'casper-client-sdk';
 import { FormState } from 'formstate';
 import {
@@ -425,7 +426,7 @@ export class DeployArgumentParser {
         );
         break;
       case SimpleType.PublicKey:
-        clValueInstance = CLValue.publicKey(decodeBase16(argValueInJson));
+        clValueInstance = CLValue.publicKey(PublicKey.fromEd25519(decodeBase16(argValueInJson)));
         break;
     }
     return clValueInstance;


### PR DESCRIPTION
## 1.0.21

### Added

- `CasperClient.getDeployByHashFromRPC` allows for getting `Deploy` instance from the Node's RPC.

### Fixed

- Secp keys generator returns `Uint8Array` instead of `Buffer`.

### Changed

- `CLValue.publicKey` accepts `PublicKey` object.