### PR TITLE
exposing the delegators object inside the bid interface of get_auctio…

### DIFF
--- a/packages/sdk/src/services/CasperServiceByJsonRPC.ts
+++ b/packages/sdk/src/services/CasperServiceByJsonRPC.ts
@@ -131,7 +131,19 @@ export interface Bid {
   staked_amount: string;
   delegation_rate: number;
   reward: string;
-  // delegators: [],
+  delegators: Delegators[];
+}
+
+export interface Delegators {
+  delegator: DelegatorInfo;
+  public_key: string;
+}
+
+export interface DelegatorInfo {
+  bonding_purse: string;
+  delegatee: string;
+  reward: string;
+  staked_amount: string;
 }
 
 export interface ValidatorBid {


### PR DESCRIPTION
…n_info

### Overview

The client SDK currently does not provide access to the delegators object inside the the bid interface, which is required in order to access delegation details that make up a validator's bid.

### Which JIRA ticket does this PR relate to?

https://casperlabs.atlassian.net/browse/ECO-911

### Complete this checklist before you submit this PR

- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
