### PR TITLE
SDK 1.0.22: ExecutableDeployItem fix.

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to casper-client-sdk.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.22
+
+### Fixed
+- Parsing `ExecutableDeployItem`'s `StoredContractByHash` from JSON to the `ExecutableDeployItem` object. 
+
 ## 1.0.21
 
 ### Added

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-client-sdk",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "main": "dist/index.js",

--- a/packages/sdk/src/lib/DeployUtil.ts
+++ b/packages/sdk/src/lib/DeployUtil.ts
@@ -476,7 +476,7 @@ export class ExecutableDeployItem implements ToBytes {
   public moduleBytes?: ModuleBytes;
 
   @jsonMember({
-    name: 'StoredVersionedContractByHash',
+    name: 'StoredContractByHash',
     constructor: StoredContractByHash
   })
   public storedContractByHash?: StoredContractByHash;


### PR DESCRIPTION
## SDK 1.0.22

### Fixed
- Parsing `ExecutableDeployItem`'s `StoredContractByHash` from JSON to the `ExecutableDeployItem` object. 
