### PR TITLE
Stops using Buffer in parseKeyPair()

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to casper-client-sdk.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.23
+
+### Changed
+- Removes use of `Buffer` in `parseKeyPair()` and instead creates new `Uint8Array` concatenating public and private keys for use as secret key in Ed25519 key pair.
 ## 1.0.22
 
 ### Fixed

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-client-sdk",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "main": "dist/index.js",

--- a/packages/sdk/src/lib/Keys.ts
+++ b/packages/sdk/src/lib/Keys.ts
@@ -186,7 +186,7 @@ export class Ed25519 extends AsymmetricKey {
     // nacl expects that the private key will contain both.
     return new Ed25519({
       publicKey: publ,
-      secretKey: Buffer.concat([priv, publ])
+      secretKey: Buffer.concat([Buffer.from(priv), Buffer.from(publ)])
     });
   }
 

--- a/packages/sdk/src/lib/Keys.ts
+++ b/packages/sdk/src/lib/Keys.ts
@@ -184,9 +184,12 @@ export class Ed25519 extends AsymmetricKey {
     const publ = Ed25519.parsePublicKey(publicKey);
     const priv = Ed25519.parsePrivateKey(privateKey);
     // nacl expects that the private key will contain both.
+    const secr = new Uint8Array(publ.length + priv.length);
+    secr.set(priv);
+    secr.set(publ, priv.length);
     return new Ed25519({
       publicKey: publ,
-      secretKey: Buffer.concat([Buffer.from(priv), Buffer.from(publ)])
+      secretKey: secr
     });
   }
 


### PR DESCRIPTION
### Overview

Removes use of Buffer in method and instead creates new Uint8Array concatenating public and private keys for use as secret key in Ed25519 key pair.

### Which JIRA ticket does this PR relate to?

No Ticket but relates to the Signer bug fix [here](https://casperlabs.atlassian.net/browse/ECO-901?atlOrigin=eyJpIjoiMWUwMjBmYjRiOWMwNGJkODk0NzhkODIyOTg3MGY0MDMiLCJwIjoiaiJ9)
### Complete this checklist before you submit this PR

- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes

_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
