### PR TITLE
fixing ValidatorInfoResult for casper-node 0.9.0+

### DIFF
--- a/packages/sdk/src/services/CasperServiceByJsonRPC.ts
+++ b/packages/sdk/src/services/CasperServiceByJsonRPC.ts
@@ -152,11 +152,16 @@ export interface ValidatorBid {
   bid: Bid;
 }
 
-export interface ValidatorsInfoResult extends RpcResult {
+export interface AuctionState {
   state_root_hash: string;
   block_height: number;
   era_validators: EraValidators[];
   bids: ValidatorBid[];
+}
+
+export interface ValidatorsInfoResult extends RpcResult {
+  api_version: string;
+  auction_state: AuctionState;
 }
 
 export class CasperServiceByJsonRPC {

--- a/packages/ui/src/components/Validators.tsx
+++ b/packages/ui/src/components/Validators.tsx
@@ -54,7 +54,7 @@ export default class Validators extends RefreshableComponent<Props, {}> {
 
   render() {
     // If data is not there, display loader.
-    let data = this.props.validatorsContainer.validatorsInfo;
+    let data = this.props.validatorsContainer.validatorsInfo?.auction_state;
     if (!data) {
       return <Loading />;
     }


### PR DESCRIPTION
### Overview

With the release of casper-node 0.9.0, the ValidatorInfoResult format has changed and the current JS SDK (1.0.23) no longer works for auction / validator information

### Which JIRA ticket does this PR relate to?

ECO-963

### Complete this checklist before you submit this PR

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes

